### PR TITLE
Remove Export MVP text from footer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -60,7 +60,7 @@
   </dialog>
 
   <footer class='footer'>
-    <small>© <span id="year"></span> Export MVP</small>
+    <small>© <span id="year"></span></small>
   </footer>
 
   <script src="/main.js" defer></script>


### PR DESCRIPTION
## Summary
- remove the "Export MVP" label from the footer so only the year remains

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc7d7709908329a46ee73dcc8fd1e2