### PR TITLE
Refine export page layout and navigation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,23 +17,10 @@
     </div>
   </header>
 
-  <!-- 레이아웃: 좌측 메뉴 + 본문 -->
-  <div class="layout">
-    <aside class="sidemenu" aria-label="좌측 메뉴">
-      <div class="menu-title">수출 및 전략물자</div>
-      <nav class="menu">
-        <button class="menu-item" data-link="/export">수출현황 <span>▶</span></button>
-        <button class="menu-item" disabled title="준비 중">전략물자 여부 체크 <span>▶</span></button>
-        <button class="menu-item" disabled title="준비 중">전문판정서 <span>▶</span></button>
-        <button class="menu-item" disabled title="준비 중">수출관리규정 <span>▶</span></button>
-        <button class="menu-item" disabled title="준비 중">설정 <span>▶</span></button>
-      </nav>
-    </aside>
-
-    <main id="app" class="content" tabindex="-1" aria-live="polite">
-      <!-- 라우팅된 화면 -->
-    </main>
-  </div>
+  <!-- 본문 -->
+  <main id="app" class="content" tabindex="-1" aria-live="polite">
+    <!-- 라우팅된 화면 -->
+  </main>
 
   <!-- 신규등록 모달 -->
   <dialog id="newExportDialog" aria-labelledby="newExportTitle">

--- a/public/main.js
+++ b/public/main.js
@@ -19,9 +19,20 @@ function renderHome() {
   setTopbarActive("/");
   document.title = "HOME | 수출 및 전략물자";
   app.innerHTML = `
-    <section class="card">
-      <h2>환영합니다 👋</h2>
-      <p>좌측 메뉴에서 <strong>수출현황</strong>을 선택해 시작하세요.</p>
+    <section class="card hero">
+      <div class="hero-text">
+        <h1>환영합니다 👋</h1>
+        <p>상단의 <strong>수출 및 전략물자</strong> 탭에서 최신 수출현황을 확인해 보세요.</p>
+      </div>
+      <a class="btn primary" href="/export" data-link role="button">수출현황 바로가기</a>
+    </section>
+    <section class="card quick-guide">
+      <h2>빠른 가이드</h2>
+      <ul class="guide-list">
+        <li>검색창에 품목, 국가 또는 상태를 입력해 원하는 데이터를 빠르게 찾을 수 있습니다.</li>
+        <li>새로운 수출 건은 <strong>수출 신규등록</strong> 버튼으로 즉시 추가하세요.</li>
+        <li>등록된 정보는 실시간으로 반영되어 목록에서 바로 확인할 수 있습니다.</li>
+      </ul>
     </section>
   `;
   app.focus();
@@ -32,37 +43,44 @@ function renderExport() {
   document.title = "수출현황 | 수출 및 전략물자";
 
   app.innerHTML = `
-    <h2>수출현황</h2>
-    <section class="search-panel" role="search">
-      <div class="row">
+    <section class="page-header">
+      <div>
+        <h1>수출현황</h1>
+        <p class="page-description">등록된 수출 건을 검색하고 신규 데이터를 추가하세요.</p>
+      </div>
+      <div class="header-actions">
+        <button id="newBtn" class="btn primary">수출 신규등록</button>
+      </div>
+    </section>
+
+    <section class="card search-panel" role="search">
+      <div class="search-input">
         <input id="q" type="text" placeholder="품목/국가/상태로 검색" aria-label="검색어" />
       </div>
-      <div class="row">
+      <div class="search-actions">
         <button id="searchBtn" class="btn">Search</button>
       </div>
     </section>
 
-    <div style="margin-top:.5rem; display:flex; justify-content:flex-end;">
-      <button id="newBtn" class="btn">수출 신규등록</button>
-    </div>
-
-    <div class="table-wrap">
-      <table aria-label="수출 목록">
-        <thead>
-          <tr>
-            <th style="width:60px;">no</th>
-            <th>품목</th>
-            <th style="width:100px;">수량</th>
-            <th style="width:120px;">단가(USD)</th>
-            <th style="width:120px;">금액(USD)</th>
-            <th style="width:110px;">국가</th>
-            <th style="width:110px;">상태</th>
-            <th style="width:160px;">등록일</th>
-          </tr>
-        </thead>
-        <tbody id="tbody"></tbody>
-      </table>
-    </div>
+    <section class="card table-card">
+      <div class="table-wrap">
+        <table aria-label="수출 목록">
+          <thead>
+            <tr>
+              <th style="width:60px;">no</th>
+              <th>품목</th>
+              <th style="width:100px;">수량</th>
+              <th style="width:120px;">단가(USD)</th>
+              <th style="width:120px;">금액(USD)</th>
+              <th style="width:110px;">국가</th>
+              <th style="width:110px;">상태</th>
+              <th style="width:160px;">등록일</th>
+            </tr>
+          </thead>
+          <tbody id="tbody"></tbody>
+        </table>
+      </div>
+    </section>
   `;
 
   // 이벤트
@@ -144,12 +162,14 @@ function renderNotFound() {
   app.focus();
 }
 
-/* Delegated nav (topbar & side menu) */
+/* Delegated navigation */
 window.addEventListener("click", (e) => {
-  const a = e.target.closest('a[data-link]');
-  if (a) { e.preventDefault(); navigate(a.getAttribute("href")); return; }
-  const btn = e.target.closest('.menu-item[data-link]');
-  if (btn) { e.preventDefault(); navigate(btn.dataset.link); return; }
+  const link = e.target.closest("[data-link]");
+  if (!link) return;
+  const href = link.getAttribute("href") || link.dataset.link;
+  if (!href) return;
+  e.preventDefault();
+  navigate(href);
 });
 window.addEventListener("popstate", () => render());
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -5,7 +5,7 @@
   --maxw:1200px;
 }
 html,body{height:100%}
-body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,Apple SD Gothic Neo,Noto Sans KR,sans-serif;line-height:1.45;color:#111;background:#fff}
+body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,Apple SD Gothic Neo,Noto Sans KR,sans-serif;line-height:1.45;color:#111;background:#f3f6fb}
 
 /* Topbar */
 .topbar{position:sticky;top:0;z-index:10;background:var(--blue);color:#fff;border-bottom:1px solid #0e2a5b}
@@ -14,31 +14,61 @@ body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,Apple SD Got
 .tab[aria-current="page"]{background:rgba(255,255,255,.15)}
 .spacer{flex:1}
 
-/* Layout */
-.layout{max-width:var(--maxw);margin:.5rem auto;display:grid;grid-template-columns:240px 1fr;gap:1rem;min-height:70vh;padding:0 .75rem}
-.sidemenu{border:1px solid var(--line)}
-.menu-title{background:#f1f4f8;font-weight:700;padding:.5rem .6rem;border-bottom:1px solid var(--line)}
-.menu{padding:.25rem}
-.menu-item{width:100%;text-align:left;padding:.4rem .6rem;border:1px solid var(--line);background:#fff;margin:.25rem 0;display:flex;justify-content:space-between;align-items:center}
-.menu-item:disabled{opacity:.6}
-
 /* Content */
-.content{border:1px solid var(--line);padding:1rem;min-height:60vh}
+.content{max-width:var(--maxw);width:calc(100% - 2rem);margin:1.5rem auto;border:1px solid var(--line);padding:1.5rem;min-height:65vh;background:#fff;display:flex;flex-direction:column;gap:1.5rem}
+@media (max-width:600px){
+  .content{width:calc(100% - 1.5rem);margin:1rem auto;padding:1.25rem;gap:1.25rem}
+}
 
 /* Cards / common */
-.card{border:1px solid var(--line);padding:1rem;background:#fff}
-h1,h2,h3{margin:.25rem 0 .75rem}
+.card{border:1px solid var(--line);padding:1.25rem;background:#fff;border-radius:10px}
+h1,h2,h3{margin:0 0 .75rem}
 
 /* Search panel */
-.search-panel{display:grid;grid-template-columns:1fr auto;gap:.75rem;border:1px solid var(--line);padding:.75rem;background:#fff}
-.search-panel .row{display:flex;gap:.5rem;align-items:center}
-.search-panel input[type="text"]{flex:1;padding:.5rem;border:1px solid var(--line)}
-.btn{padding:.5rem .8rem;border:1px solid var(--line);background:#fff;cursor:pointer}
+.search-panel{display:grid;gap:1rem}
+.search-input input[type="text"]{width:100%;padding:.65rem .75rem;border:1px solid var(--line);border-radius:6px;background:#fff}
+.search-actions{display:flex;justify-content:flex-end}
+.search-actions .btn{width:100%}
+@media (min-width:600px){
+  .search-panel{grid-template-columns:minmax(0,1fr) auto;align-items:stretch}
+  .search-actions{justify-content:flex-start}
+  .search-actions .btn{width:auto}
+}
+
+.btn{display:inline-flex;align-items:center;justify-content:center;gap:.25rem;padding:.55rem .95rem;border:1px solid var(--line);background:#fff;color:inherit;font:inherit;border-radius:6px;cursor:pointer;text-decoration:none;transition:background .2s ease,border-color .2s ease,color .2s ease}
+.btn:hover{background:#f1f4f8}
+.btn:disabled{opacity:.6;cursor:not-allowed}
 .btn.primary{background:var(--blue);color:#fff;border-color:#0e2a5b}
+.btn.primary:hover{background:#0e2a5b}
+
+/* Home */
+.hero{display:flex;flex-direction:column;gap:1rem;align-items:flex-start}
+.hero-text p{margin:.5rem 0 0;color:#333}
+.hero .btn{align-self:stretch}
+@media (min-width:720px){
+  .hero{flex-direction:row;align-items:center;justify-content:space-between}
+  .hero-text{max-width:60%}
+  .hero .btn{align-self:center;width:auto}
+}
+
+.quick-guide h2{margin:0 0 .75rem}
+.guide-list{margin:0;padding-left:1.2rem;color:#444;line-height:1.6}
+.guide-list li+li{margin-top:.35rem}
+
+/* Export page */
+.page-header{display:flex;flex-direction:column;gap:1rem}
+.page-header h1{margin:0}
+.page-description{margin:.5rem 0 0;color:#444;font-size:.95rem}
+.header-actions{display:flex;gap:.5rem;align-items:center}
+@media (min-width:768px){
+  .page-header{flex-direction:row;align-items:flex-end;justify-content:space-between}
+  .header-actions{align-items:flex-end}
+}
 
 /* Table */
-.table-wrap{margin-top:1rem}
+.table-wrap{margin-top:0;overflow-x:auto}
 table{width:100%;border-collapse:collapse}
+.table-card table{min-width:720px}
 th,td{border:1px solid var(--line);padding:.5rem;vertical-align:middle}
 th{background:#f5f5f5;text-align:left}
 tbody tr:hover{background:#fafcff}
@@ -53,4 +83,7 @@ input,select{padding:.5rem;border:1px solid var(--line)}
 .primary{background:var(--blue);color:#fff;border-color:#0e2a5b}
 
 /* Footer */
-.footer{max-width:var(--maxw);margin:1rem auto;padding:0 .75rem;color:#555}
+.footer{max-width:var(--maxw);width:calc(100% - 2rem);margin:0 auto 2rem;padding:0;color:#555}
+@media (max-width:600px){
+  .footer{width:calc(100% - 1.5rem);margin:0 auto 1.5rem}
+}


### PR DESCRIPTION
## Summary
- remove the fixed sidebar container so routing content fills the page
- redesign the home hero and export page sections so the export list lives under the top tab
- refresh shared styles for buttons, search panel, and table layout to use the wider space

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc8a68cf148329acf01b85129c2ce8