### PR TITLE
Align export table wording with reference image

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -170,7 +170,7 @@ function renderExport() {
       </div>
       <div class="header-actions">
         <button id="newBtn" class="btn primary" type="button">신규등록</button>
-        <button id="editBtn" class="btn" type="button">수정·변경</button>
+        <button id="editBtn" class="btn" type="button">수정요청</button>
         <button id="confirmBtn" class="btn" type="button">확인완료</button>
       </div>
     </section>
@@ -193,11 +193,11 @@ function renderExport() {
             <col class="col-receipt" />
             <col class="col-project" />
             <col class="col-project-code" />
-            <col class="col-item" />
-            <col class="col-qty" />
-            <col class="col-spec" />
-            <col class="col-client" />
-            <col class="col-maker" />
+          <col class="col-item" />
+          <col class="col-spec" />
+          <col class="col-client" />
+          <col class="col-maker" />
+          <col class="col-qty" />
             <col class="col-country" />
             <col class="col-incoterm" />
             <col class="col-port" />
@@ -218,10 +218,10 @@ function renderExport() {
               <th scope="col" rowspan="2">프로젝트명</th>
               <th scope="col" rowspan="2">프로젝트코드</th>
               <th scope="col" rowspan="2">품목명</th>
-              <th scope="col" rowspan="2">수량</th>
               <th scope="col" rowspan="2">규격</th>
               <th scope="col" rowspan="2">거래처</th>
               <th scope="col" rowspan="2">제작사</th>
+              <th scope="col" rowspan="2">수량</th>
               <th scope="col" rowspan="2">수출국가</th>
               <th scope="col" rowspan="2">인도방법</th>
               <th scope="col" rowspan="2">선적항</th>
@@ -233,7 +233,7 @@ function renderExport() {
             <tr>
               <th scope="col">%</th>
               <th scope="col">M/V/V/C</th>
-              <th scope="col">전환일자</th>
+              <th scope="col">재고전환서류제출일</th>
               <th scope="col">수리일자</th>
               <th scope="col">신고필증 수취일</th>
             </tr>
@@ -361,10 +361,10 @@ function renderRows(rows = [], meta = {}) {
           ${td("-", { align: "left", empty: true })}
           ${td("-", { align: "left", empty: true })}
           ${td(item, { align: "left", empty: item === "-" })}
+          ${td("-", { align: "left", empty: true })}
+          ${td("-", { align: "left", empty: true })}
+          ${td("-", { align: "left", empty: true })}
           ${td(qty, { align: "right", empty: qty === "-" })}
-          ${td("-", { align: "left", empty: true })}
-          ${td("-", { align: "left", empty: true })}
-          ${td("-", { align: "left", empty: true })}
           ${td(country, { align: "center", empty: country === "-" })}
           ${td("-", { align: "left", empty: true })}
           ${td("-", { align: "left", empty: true })}

--- a/public/styles.css
+++ b/public/styles.css
@@ -105,11 +105,11 @@ tbody tr:hover{background:#fafcff}
 .export-table col.col-note{width:160px}
 .export-table col.col-progress{width:80px}
 .export-table col.col-vessel{width:150px}
-.export-table col.col-conversion{width:150px}
+.export-table col.col-conversion{width:200px}
 .export-table col.col-clearance{width:150px}
 .export-table col.col-certificate{width:170px}
-.export-table td,.export-table th{white-space:nowrap}
-.export-table td{text-align:center}
+.export-table th{white-space:normal;line-height:1.35}
+.export-table td{white-space:nowrap;text-align:center}
 .export-table td[data-empty="true"]{color:#a3abbb}
 .export-table td.error{color:#d23c3c;font-weight:600;text-align:center}
 .export-table .text-left{text-align:left}


### PR DESCRIPTION
## Summary
- update the export action buttons and table column labels to mirror the provided reference
- reorder the export table columns so the layout matches the reference image
- allow table headers to wrap and widen the long submission column for clarity

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d3e1517d5883298c1034be70954ba6