### PR TITLE
Align export table columns with requested layout

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -5,7 +5,7 @@ const $$ = (sel, root = document) => [...root.querySelectorAll(sel)];
 const app = $("#app");
 
 const PAGE_SIZE = 20;
-const EXPORT_TABLE_COLSPAN = 21;
+const EXPORT_TABLE_COLSPAN = 22;
 let currentPage = 1;
 let currentQuery = "";
 let lastMeta = { totalPages: 0, totalCount: 0, pageSize: PAGE_SIZE };
@@ -189,49 +189,51 @@ function renderExport() {
         <table class="export-table" aria-label="수출 목록">
           <colgroup>
             <col class="col-no" />
+            <col class="col-type" />
             <col class="col-date" />
-            <col class="col-receipt" />
             <col class="col-project" />
             <col class="col-project-code" />
             <col class="col-item" />
-            <col class="col-spec" />
-            <col class="col-client" />
-            <col class="col-maker" />
-            <col class="col-origin" />
-            <col class="col-terms" />
             <col class="col-qty" />
-            <col class="col-unit-price" />
+            <col class="col-client" />
+            <col class="col-end-user" />
             <col class="col-country" />
-            <col class="col-method" />
-            <col class="col-port" />
-            <col class="col-destination" />
-            <col class="col-insurance" />
-            <col class="col-exporter" />
+            <col class="col-dept" />
+            <col class="col-manager" />
+            <col class="col-select" />
+            <col class="col-pl" />
+            <col class="col-invoice" />
+            <col class="col-permit" />
+            <col class="col-declaration" />
+            <col class="col-usage" />
+            <col class="col-bl" />
+            <col class="col-file" />
             <col class="col-status" />
             <col class="col-note" />
           </colgroup>
           <thead>
             <tr>
-              <th scope="col">No</th>
-              <th scope="col">요청일</th>
-              <th scope="col">접수</th>
+              <th scope="col">NO</th>
+              <th scope="col">출고유형</th>
+              <th scope="col">출고일</th>
               <th scope="col">프로젝트명</th>
               <th scope="col">프로젝트코드</th>
-              <th scope="col">품명</th>
-              <th scope="col">규격</th>
-              <th scope="col">거래처</th>
-              <th scope="col">제작사</th>
-              <th scope="col">원산지</th>
-              <th scope="col">인도조건</th>
+              <th scope="col">품목명</th>
               <th scope="col">수량</th>
-              <th scope="col">단가</th>
+              <th scope="col">거래처</th>
+              <th scope="col">최종사용자</th>
               <th scope="col">수출국가</th>
-              <th scope="col">인도방법</th>
-              <th scope="col">선적항</th>
-              <th scope="col">도착항</th>
-              <th scope="col">보험유무</th>
-              <th scope="col">수출자</th>
-              <th scope="col">이행상태</th>
+              <th scope="col">담당부서</th>
+              <th scope="col">담당자</th>
+              <th scope="col">선택</th>
+              <th scope="col">PL</th>
+              <th scope="col">INVOICE</th>
+              <th scope="col">전략물자 수출허가서</th>
+              <th scope="col">수출신고필증</th>
+              <th scope="col">최종사용자/용도확인</th>
+              <th scope="col">B/L</th>
+              <th scope="col">파일등록 및 수정</th>
+              <th scope="col">진행상황</th>
               <th scope="col">비고</th>
             </tr>
           </thead>
@@ -340,44 +342,49 @@ function renderRows(rows = [], meta = {}) {
   }
 
   const qtyFormatter = new Intl.NumberFormat("ko-KR");
-  const priceFormatter = new Intl.NumberFormat("ko-KR", {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  });
 
   tbody.innerHTML = rows
     .map((row, idx) => {
       const seq = startIndex + idx + 1;
       const createdDate = formatDate(row.createdAt);
-      const qty = formatNumber(row.qty, qtyFormatter);
-      const unitPrice = formatNumber(row.unitPrice, priceFormatter);
+      const shipmentType = row.shipmentType ? escapeHtml(String(row.shipmentType)) : "-";
+      const projectName = row.projectName ? escapeHtml(String(row.projectName)) : "-";
+      const projectCode = row.projectCode ? escapeHtml(String(row.projectCode)) : "-";
       const item = row.item ? escapeHtml(String(row.item)) : "-";
+      const qty = formatNumber(row.qty, qtyFormatter);
+      const client = row.client ? escapeHtml(String(row.client)) : "-";
+      const endUser = row.endUser ? escapeHtml(String(row.endUser)) : "-";
       const country = row.country ? escapeHtml(String(row.country).toUpperCase()) : "-";
+      const department = row.department ? escapeHtml(String(row.department)) : "-";
+      const manager = row.manager ? escapeHtml(String(row.manager)) : "-";
       const status = row.status ? escapeHtml(String(row.status)) : "-";
+      const note = row.note ? escapeHtml(String(row.note)) : "-";
+      const selectBox = "<input type='checkbox' disabled aria-label='선택' />";
 
       return `
         <tr>
           ${td(String(seq), { align: "center" })}
+          ${td(shipmentType, { empty: shipmentType === "-" })}
           ${td(createdDate, { empty: createdDate === "-" })}
-          ${td("-", { empty: true })}
-          ${td("-", { align: "left", empty: true })}
-          ${td("-", { align: "left", empty: true })}
+          ${td(projectName, { align: "left", empty: projectName === "-" })}
+          ${td(projectCode, { align: "left", empty: projectCode === "-" })}
           ${td(item, { align: "left", empty: item === "-" })}
-          ${td("-", { align: "left", empty: true })}
-          ${td("-", { align: "left", empty: true })}
-          ${td("-", { align: "left", empty: true })}
-          ${td("-", { align: "left", empty: true })}
-          ${td("-", { align: "left", empty: true })}
           ${td(qty, { align: "right", empty: qty === "-" })}
-          ${td(unitPrice, { align: "right", empty: unitPrice === "-" })}
+          ${td(client, { align: "left", empty: client === "-" })}
+          ${td(endUser, { align: "left", empty: endUser === "-" })}
           ${td(country, { align: "center", empty: country === "-" })}
-          ${td("-", { align: "left", empty: true })}
-          ${td("-", { align: "left", empty: true })}
-          ${td("-", { align: "left", empty: true })}
-          ${td("-", { align: "left", empty: true })}
-          ${td("-", { align: "left", empty: true })}
+          ${td(department, { align: "left", empty: department === "-" })}
+          ${td(manager, { align: "left", empty: manager === "-" })}
+          ${td(selectBox, { align: "center" })}
+          ${td("-", { empty: true })}
+          ${td("-", { empty: true })}
+          ${td("-", { empty: true })}
+          ${td("-", { empty: true })}
+          ${td("-", { empty: true })}
+          ${td("-", { empty: true })}
+          ${td("-", { empty: true })}
           ${td(status, { align: "left", empty: status === "-" })}
-          ${td("-", { align: "left", empty: true })}
+          ${td(note, { align: "left", empty: note === "-" })}
         </tr>
       `;
     })

--- a/public/styles.css
+++ b/public/styles.css
@@ -80,36 +80,38 @@ h1,h2,h3{margin:0 0 .75rem}
 /* Table */
 .table-wrap{margin-top:0;overflow-x:auto}
 table{width:100%;border-collapse:collapse}
-.table-card table{min-width:1500px}
+.table-card table{min-width:1900px}
 th,td{border:1px solid var(--line);padding:.55rem .6rem;vertical-align:middle;font-size:.85rem}
 th{background:#f5f5f5;text-align:left}
 tbody tr:hover{background:#fafcff}
 
 .export-table th{background:#e8eefc;text-align:center}
 .export-table col.col-no{width:60px}
+.export-table col.col-type{width:120px}
 .export-table col.col-date{width:120px}
-.export-table col.col-receipt{width:120px}
-.export-table col.col-project{width:180px}
+.export-table col.col-project{width:200px}
 .export-table col.col-project-code{width:150px}
 .export-table col.col-item{width:220px}
-.export-table col.col-spec{width:150px}
-.export-table col.col-client{width:160px}
-.export-table col.col-maker{width:160px}
-.export-table col.col-origin{width:140px}
-.export-table col.col-terms{width:130px}
 .export-table col.col-qty{width:90px}
-.export-table col.col-unit-price{width:110px}
+.export-table col.col-client{width:160px}
+.export-table col.col-end-user{width:160px}
 .export-table col.col-country{width:110px}
-.export-table col.col-method{width:130px}
-.export-table col.col-port{width:140px}
-.export-table col.col-destination{width:140px}
-.export-table col.col-insurance{width:120px}
-.export-table col.col-exporter{width:130px}
-.export-table col.col-status{width:130px}
-.export-table col.col-note{width:160px}
+.export-table col.col-dept{width:150px}
+.export-table col.col-manager{width:140px}
+.export-table col.col-select{width:80px}
+.export-table col.col-pl{width:130px}
+.export-table col.col-invoice{width:130px}
+.export-table col.col-permit{width:180px}
+.export-table col.col-declaration{width:150px}
+.export-table col.col-usage{width:180px}
+.export-table col.col-bl{width:130px}
+.export-table col.col-file{width:180px}
+.export-table col.col-status{width:140px}
+.export-table col.col-note{width:180px}
 .export-table th{white-space:normal;line-height:1.35}
 .export-table td{white-space:nowrap;text-align:center}
 .export-table td[data-empty="true"]{color:#a3abbb}
+.export-table td input[type="checkbox"]{width:16px;height:16px}
 .export-table td.error{color:#d23c3c;font-weight:600;text-align:center}
 .export-table .text-left{text-align:left}
 .export-table .text-right{text-align:right}


### PR DESCRIPTION
## Summary
- update the 수출현황 테이블 컬럼을 요청된 항목 순서에 맞춰 재구성하고 신규 필드를 렌더링
- 기본 데이터 필드가 없는 항목은 빈 값/체크박스로 표시하고 수량, 상태, 비고를 정렬 유지
- 테이블 열 너비와 체크박스 스타일을 조정해 추가된 컬럼에 맞게 UI를 정리

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d476cb562c832999f1f81fbcb3fe9d