### PR TITLE
Group export evidence columns and fix cancel

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -51,7 +51,7 @@
         </label>
       </div>
       <menu class="dialog-actions">
-        <button type="reset" value="cancel">취소</button>
+        <button type="button" data-dialog-cancel>취소</button>
         <button type="submit" value="confirm" class="primary">등록</button>
       </menu>
     </form>

--- a/public/main.js
+++ b/public/main.js
@@ -213,28 +213,31 @@ function renderExport() {
           </colgroup>
           <thead>
             <tr>
-              <th scope="col">NO</th>
-              <th scope="col">출고유형</th>
-              <th scope="col">출고일</th>
-              <th scope="col">프로젝트명</th>
-              <th scope="col">프로젝트코드</th>
-              <th scope="col">품목명</th>
-              <th scope="col">수량</th>
-              <th scope="col">거래처</th>
-              <th scope="col">최종사용자</th>
-              <th scope="col">수출국가</th>
-              <th scope="col">담당부서</th>
-              <th scope="col">담당자</th>
-              <th scope="col">선택</th>
+              <th scope="col" rowspan="2">NO</th>
+              <th scope="col" rowspan="2">출고유형</th>
+              <th scope="col" rowspan="2">출고일</th>
+              <th scope="col" rowspan="2">프로젝트명</th>
+              <th scope="col" rowspan="2">프로젝트코드</th>
+              <th scope="col" rowspan="2">품목명</th>
+              <th scope="col" rowspan="2">수량</th>
+              <th scope="col" rowspan="2">거래처</th>
+              <th scope="col" rowspan="2">최종사용자</th>
+              <th scope="col" rowspan="2">수출국가</th>
+              <th scope="col" rowspan="2">담당부서</th>
+              <th scope="col" rowspan="2">담당자</th>
+              <th scope="col" rowspan="2">선택</th>
+              <th scope="colgroup" colspan="6">수출증빙</th>
+              <th scope="col" rowspan="2">파일등록 및 수정</th>
+              <th scope="col" rowspan="2">진행상황</th>
+              <th scope="col" rowspan="2">비고</th>
+            </tr>
+            <tr>
               <th scope="col">PL</th>
               <th scope="col">INVOICE</th>
               <th scope="col">전략물자 수출허가서</th>
-              <th scope="col">수출신고필증</th>
+              <th scope="col">수출신고서</th>
               <th scope="col">최종사용자/용도확인</th>
               <th scope="col">B/L</th>
-              <th scope="col">파일등록 및 수정</th>
-              <th scope="col">진행상황</th>
-              <th scope="col">비고</th>
             </tr>
           </thead>
           <tbody id="tbody"></tbody>
@@ -482,6 +485,18 @@ function openNewDialog() {
   const form = $("#newExportForm");
   form.reset();
   dialog.showModal();
+
+  const cancelButton = form.querySelector("[data-dialog-cancel]");
+  if (cancelButton) {
+    cancelButton.addEventListener(
+      "click",
+      () => {
+        form.reset();
+        dialog.close();
+      },
+      { once: true }
+    );
+  }
 
   form.onsubmit = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- add a grouped header row that collects the export evidence columns under a single "수출증빙" heading and rename the export declaration column
- keep the modal cancel control accessible by changing it to a dedicated button
- close and reset the new export dialog when cancel is pressed so the dialog behaves as expected

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d47ae18e548329955e2f98a170a2cb