### PR TITLE
Expand export page content width

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -25,7 +25,7 @@ body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,Apple SD Got
 .spacer{flex:1}
 
 /* Content */
-.content{max-width:var(--maxw);width:calc(100% - 2rem);margin:1.5rem auto;border:1px solid var(--line);padding:1.5rem;min-height:65vh;background:#fff;display:flex;flex-direction:column;gap:1.5rem}
+.content{width:100%;margin:1.5rem 0;padding:1.5rem 2rem;min-height:65vh;background:#fff;display:flex;flex-direction:column;gap:1.5rem}
 @media (max-width:600px){
   .content{width:calc(100% - 1.5rem);margin:1rem auto;padding:1.25rem;gap:1.25rem}
 }
@@ -135,7 +135,7 @@ input,select{padding:.5rem;border:1px solid var(--line)}
 .primary{background:var(--blue);color:#fff;border-color:#0e2a5b}
 
 /* Footer */
-.footer{max-width:var(--maxw);width:calc(100% - 2rem);margin:0 auto 2rem;padding:0;color:#555}
+.footer{width:100%;margin:0 0 2rem;padding:0 2rem;color:#555}
 @media (max-width:600px){
-  .footer{width:calc(100% - 1.5rem);margin:0 auto 1.5rem}
+  .footer{width:calc(100% - 1.5rem);margin:0 auto 1.5rem;padding:0}
 }


### PR DESCRIPTION
## Summary
- expand the main content area to span the full viewport width on desktop
- update the footer layout to align with the wider content area

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d47c59b2d483299cbcec655442432b