### PR TITLE
Revise export registration flow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,172 +38,70 @@
     <form id="newExportForm" method="dialog" class="card">
       <header class="dialog-header">
         <h3 id="newExportTitle">수출 신규등록</h3>
-        <p id="newExportStep" class="step-indicator" aria-live="polite">1 / 13</p>
-        <p id="newExportSection" class="step-title">수출업체 기본정보</p>
+        <p id="newExportStep" class="step-indicator" aria-live="polite">1 / 4</p>
+        <p id="newExportSection" class="step-title">수출목적</p>
       </header>
       <div class="step-container">
-        <section class="step" data-step="0" data-step-title="수출업체 기본정보">
+        <section class="step" data-step="0" data-step-title="수출목적">
           <div class="grid">
-            <label>업체명<input name="companyName" placeholder="예: 한빛테크" /></label>
-            <label>사업자등록번호<input name="businessNumber" placeholder="예: 123-45-67890" /></label>
-            <label>담당자명<input name="contactName" placeholder="예: 홍길동" /></label>
-            <label>담당자 연락처<input name="contactPhone" placeholder="예: 010-1234-5678" /></label>
-          </div>
-        </section>
-        <section class="step" data-step="1" data-step-title="출고 기본정보">
-          <div class="grid">
-            <label>출고유형
-              <select name="shipmentType" required>
+            <label>수출유형
+              <select name="exportType" required>
                 <option value="">선택</option>
-                <option value="일반수출">일반수출</option>
-                <option value="위탁가공">위탁가공</option>
-                <option value="임시반출">임시반출</option>
-                <option value="타법령">타법령</option>
-              </select>
-            </label>
-            <label>출고일<input name="shipmentDate" type="date" /></label>
-            <label>출고목적
-              <select name="shipmentPurpose">
-                <option value="">선택</option>
-                <option value="상업">상업</option>
-                <option value="연구">연구</option>
+                <option value="정상판매">정상판매</option>
                 <option value="A/S">A/S</option>
+                <option value="BMT">BMT</option>
+                <option value="장애교체">장애교체</option>
+                <option value="TEST">TEST</option>
+                <option value="Stock">Stock</option>
+                <option value="임대">임대</option>
+                <option value="유상임대">유상임대</option>
+                <option value="기타 장애교체">기타 장애교체</option>
+                <option value="기타 A/S">기타 A/S</option>
+                <option value="제조사샘플">제조사샘플</option>
+                <option value="개발용샘플">개발용샘플</option>
+                <option value="기타">기타</option>
               </select>
             </label>
+            <label data-export-type-detail hidden>기타 사유<input name="exportTypeDetail" placeholder="수출유형을 입력해주세요" /></label>
+            <label>프로젝트 명<input name="projectName" required placeholder="예: 프로젝트명" /></label>
+            <label>프로젝트 코드<input name="projectCode" required placeholder="예: PJT-2024-001" /></label>
           </div>
         </section>
-        <section class="step" data-step="2" data-step-title="프로젝트 및 계약">
+        <section class="step" data-step="1" data-step-title="전략물자 여부 확인">
           <div class="grid">
-            <label>프로젝트명<input name="projectName" placeholder="예: 차세대 반도체" /></label>
-            <label>프로젝트코드<input name="projectCode" placeholder="예: PJT-2024-001" /></label>
-            <label>계약번호<input name="contractNumber" placeholder="예: CNT-24001" /></label>
+            <fieldset class="checkbox-group" data-required-group>
+              <legend>전략물자 여부</legend>
+              <label><input type="checkbox" value="전략물자 수출" data-strategic-option /> 전략물자 수출</label>
+              <label><input type="checkbox" value="일반수출" data-strategic-option /> 일반수출</label>
+              <input type="hidden" name="strategicFlag" data-strategic-value />
+            </fieldset>
           </div>
         </section>
-        <section class="step" data-step="3" data-step-title="품목 정보">
+        <section class="step" data-step="2" data-step-title="담당자 정보">
           <div class="grid">
-            <label>품목명<input name="item" required placeholder="예: 반도체 웨이퍼" /></label>
-            <label>모델/규격<input name="itemSpec" placeholder="예: 300mm 12"" /></label>
-            <label>HS CODE<input name="hsCode" placeholder="예: 381800" /></label>
+            <label>이름<input name="managerName" required placeholder="예: 홍길동" /></label>
+            <label>부서<input name="managerDepartment" required placeholder="예: 영업팀" /></label>
+            <label>연락처<input name="managerPhone" required placeholder="예: 010-0000-0000" /></label>
+            <label>메일주소<input name="managerEmail" type="email" required placeholder="예: example@example.com" /></label>
           </div>
         </section>
-        <section class="step" data-step="4" data-step-title="수량 및 금액">
+        <section class="step" data-step="3" data-step-title="수입자 정보">
           <div class="grid">
-            <label>수량<input name="qty" type="number" min="0" step="1" required /></label>
-            <label>단위<input name="unit" placeholder="EA" /></label>
-            <label>단가(USD)<input name="unitPrice" type="number" min="0" step="0.01" required /></label>
-          </div>
-        </section>
-        <section class="step" data-step="5" data-step-title="거래처 정보">
-          <div class="grid">
-            <label>거래처<input name="client" placeholder="예: 글로벌전자" /></label>
-            <label>거래처 국가<input name="clientCountry" placeholder="예: KR" /></label>
-            <label>거래처 담당자<input name="clientManager" placeholder="예: John Doe" /></label>
-          </div>
-        </section>
-        <section class="step" data-step="6" data-step-title="최종사용자 및 용도">
-          <div class="grid">
-            <label>최종사용자<input name="endUser" placeholder="예: ABC 연구소" /></label>
-            <label>최종사용자 국가<input name="endUserCountry" placeholder="예: US" /></label>
-            <label>최종사용 용도<textarea name="endUse" rows="2" placeholder="예: 연구 및 시험용"></textarea></label>
-          </div>
-        </section>
-        <section class="step" data-step="7" data-step-title="수출국가 및 운송">
-          <div class="grid">
-            <label>수출국가<input name="country" required placeholder="예: US" /></label>
-            <label>운송방법
-              <select name="transportMode">
-                <option value="">선택</option>
-                <option value="항공">항공</option>
-                <option value="해상">해상</option>
-                <option value="특송">특송</option>
-              </select>
-            </label>
-            <label>선적예정일<input name="departureDate" type="date" /></label>
-          </div>
-        </section>
-        <section class="step" data-step="8" data-step-title="내부 담당 정보">
-          <div class="grid">
-            <label>담당부서<input name="department" placeholder="예: 해외영업팀" /></label>
-            <label>담당자<input name="manager" placeholder="예: 김대리" /></label>
-            <label>담당자 이메일<input name="managerEmail" type="email" placeholder="예: export@example.com" /></label>
-          </div>
-        </section>
-        <section class="step" data-step="9" data-step-title="전략물자 판정">
-          <div class="grid">
-            <label>전략물자 여부
-              <select name="strategicFlag">
-                <option value="">선택</option>
-                <option value="해당">해당</option>
-                <option value="비해당">비해당</option>
-              </select>
-            </label>
-            <label>전략물자 분류<input name="strategicCategory" placeholder="예: C-3" /></label>
-            <label>판정 근거<textarea name="strategicBasis" rows="2" placeholder="판정 기준 메모"></textarea></label>
-          </div>
-        </section>
-        <section class="step" data-step="10" data-step-title="허가 및 신고 정보">
-          <div class="grid">
-            <label>허가구분<input name="permitType" placeholder="예: 전략물자 수출허가" /></label>
-            <label>허가번호<input name="permitNumber" placeholder="허가번호" /></label>
-            <label>신고번호<input name="declarationNumber" placeholder="신고번호" /></label>
-          </div>
-        </section>
-        <section class="step" data-step="11" data-step-title="수출증빙 현황">
-          <div class="grid">
-            <label>PL 준비상태
-              <select name="plStatus">
-                <option value="미등록">미등록</option>
-                <option value="등록완료">등록완료</option>
-              </select>
-            </label>
-            <label>INVOICE 준비상태
-              <select name="invoiceStatus">
-                <option value="미등록">미등록</option>
-                <option value="등록완료">등록완료</option>
-              </select>
-            </label>
-            <label>전략물자 수출허가서
-              <select name="permitStatus">
-                <option value="미등록">미등록</option>
-                <option value="등록완료">등록완료</option>
-              </select>
-            </label>
-            <label>수출신고서 상태
-              <select name="declarationStatus">
-                <option value="미등록">미등록</option>
-                <option value="등록완료">등록완료</option>
-              </select>
-            </label>
-            <label>최종사용자/용도 확인서
-              <select name="usageStatus">
-                <option value="미등록">미등록</option>
-                <option value="등록완료">등록완료</option>
-              </select>
-            </label>
-            <label>B/L 상태
-              <select name="blStatus">
-                <option value="미등록">미등록</option>
-                <option value="등록완료">등록완료</option>
-              </select>
-            </label>
-            <label>파일 메모<textarea name="fileNote" rows="2" placeholder="첨부 파일 메모"></textarea></label>
-          </div>
-        </section>
-        <section class="step" data-step="12" data-step-title="진행상황 및 비고">
-          <div class="grid">
-            <label>진행상황
-              <select name="status" required>
-                <option value="대기">대기</option>
-                <option value="진행">진행</option>
-                <option value="완료">완료</option>
-              </select>
-            </label>
-            <label>비고<textarea name="note" rows="3" placeholder="특이사항 메모"></textarea></label>
+            <label>회사명<input name="importCompanyName" required placeholder="예: ABC Corp." /></label>
+            <label>주소<input name="importAddress" required placeholder="예: 서울특별시 ..." /></label>
+            <label>국가<input name="importCountry" required placeholder="예: 대한민국" /></label>
+            <label>국가번호<input name="importCountryCode" required placeholder="예: 82" /></label>
+            <label>전화번호<input name="importPhone" required placeholder="예: 02-000-0000" /></label>
+            <label>이름<input name="importContactName" required placeholder="예: John Doe" /></label>
+            <label>연락처<input name="importContactPhone" required placeholder="예: +82-10-0000-0000" /></label>
+            <label>이메일<input name="importEmail" type="email" required placeholder="예: contact@example.com" /></label>
+            <label>기타<textarea name="importEtc" rows="3" placeholder="추가 정보를 입력해주세요"></textarea></label>
           </div>
         </section>
       </div>
       <menu class="dialog-actions">
-        <button type="button" data-step-next class="btn">다음</button>
+        <button type="button" data-step-prev class="btn">이전 단계</button>
+        <button type="button" data-step-next class="btn">다음 단계</button>
         <button type="button" data-step-save class="btn">임시저장</button>
         <button type="submit" data-step-complete class="btn primary" disabled>완료</button>
         <button type="button" data-dialog-cancel class="btn">취소</button>


### PR DESCRIPTION
## Summary
- replace the 13-step registration popup with a four-step flow focused on export purpose, strategic classification, 담당자, and importer details, including a detail field that appears when 기타 is selected
- activate the export list selection column, add the conditional "이어서 등록하기" button, and only surface it when 임시저장 rows are checked
- tighten the modal navigation with 이전/다음 단계 controls, live validation that disables progression when required data is missing, and skip refreshing the list after submission so new entries aren’t auto-matched

## Testing
- `node --check public/main.js`

------
https://chatgpt.com/codex/tasks/task_e_68d4e0a7b0d88329a94e435bd1a108da