### PR TITLE
feat: add currency selection and fix registration failure

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -214,6 +214,7 @@
                   <th scope="col">품명</th>
                   <th scope="col">품목구분</th>
                   <th scope="col">수량</th>
+                  <th scope="col">통화</th>
                   <th scope="col">단가</th>
                   <th scope="col">총액</th>
                   <th scope="col">생산국</th>

--- a/public/styles.css
+++ b/public/styles.css
@@ -160,6 +160,8 @@ input,select,textarea{padding:.5rem;border:1px solid var(--line);border-radius:6
 .item-table tbody input{width:100%}
 .item-table tbody input[type="number"]{text-align:right}
 .item-table tbody input[readonly]{background:#f7f8fb}
+.item-table tbody select{width:100%}
+.item-origin-field{display:flex;flex-direction:column;gap:.35rem}
 .step-container{display:flex;flex-direction:column;gap:1.25rem;margin-top:1rem}
 .step{display:block}
 .step[hidden]{display:none}


### PR DESCRIPTION
## Summary
- add a currency dropdown and dynamic origin selector with custom input to the item entry table
- include currency/origin utilities in the form logic and keep step validation in sync when rows change
- fix the registration failure by mapping the item table data to the API contract when submitting

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d51fef7ac4832986dc1da15913a325