### PR TITLE
feat: toggle packing creation form

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -246,42 +246,53 @@
         </section>
         <section class="step" data-step="12" data-step-title="팩킹리스트" data-packing-step>
           <div class="packing-layout">
-            <section class="packing-panel">
-              <header class="packing-panel-header">
-                <h4>팩킹정보</h4>
-                <p>생성된 Packing의 요약을 확인하세요.</p>
-              </header>
-              <p class="packing-empty" data-packing-empty>등록된 팩킹이 없습니다. 오른쪽에서 팩킹을 생성해주세요.</p>
-              <ul class="packing-card-list" data-packing-list></ul>
-            </section>
-            <section class="packing-panel">
-              <header class="packing-panel-header">
-                <h4>팩킹 생성</h4>
-                <p>Packing 정보를 입력해주세요.</p>
-              </header>
-              <div class="packing-form" data-packing-form>
-                <label>팩킹명
-                  <input type="text" name="packingName" data-packing-field="name" placeholder="예: Packing 01" />
-                </label>
-                <div class="packing-dimension-grid">
-                  <label>Length (cm)
-                    <input type="number" name="packingLength" min="0" step="0.1" data-packing-field="length" placeholder="0" />
+            <div class="packing-layout-actions">
+              <button type="button" class="btn primary" data-packing-open>팩킹 생성</button>
+            </div>
+            <div class="packing-layout-body">
+              <section class="packing-panel">
+                <header class="packing-panel-header">
+                  <div class="packing-panel-heading">
+                    <h4>팩킹정보</h4>
+                    <p>생성된 Packing의 요약을 확인하세요.</p>
+                  </div>
+                </header>
+                <p class="packing-empty" data-packing-empty>등록된 팩킹이 없습니다. 우측 상단의 버튼을 눌러 팩킹을 생성해주세요.</p>
+                <ul class="packing-card-list" data-packing-list></ul>
+              </section>
+              <section class="packing-panel packing-create-panel" data-packing-panel hidden>
+                <header class="packing-panel-header">
+                  <div class="packing-panel-heading">
+                    <h4>팩킹 생성</h4>
+                    <p>Packing 정보를 입력해주세요.</p>
+                  </div>
+                  <button type="button" class="packing-panel-close" data-packing-close aria-label="팩킹 생성 닫기">×</button>
+                </header>
+                <div class="packing-form" data-packing-form>
+                  <label>팩킹명
+                    <input type="text" name="packingName" data-packing-field="name" placeholder="예: Packing 01" />
                   </label>
-                  <label>Width (cm)
-                    <input type="number" name="packingWidth" min="0" step="0.1" data-packing-field="width" placeholder="0" />
-                  </label>
-                  <label>Height (cm)
-                    <input type="number" name="packingHeight" min="0" step="0.1" data-packing-field="height" placeholder="0" />
-                  </label>
-                  <label>CBM
-                    <input type="number" name="packingCbm" min="0" step="0.001" data-packing-field="cbm" placeholder="0.000" />
-                  </label>
+                  <div class="packing-dimension-grid">
+                    <label>Length (cm)
+                      <input type="number" name="packingLength" min="0" step="0.1" data-packing-field="length" placeholder="0" />
+                    </label>
+                    <label>Width (cm)
+                      <input type="number" name="packingWidth" min="0" step="0.1" data-packing-field="width" placeholder="0" />
+                    </label>
+                    <label>Height (cm)
+                      <input type="number" name="packingHeight" min="0" step="0.1" data-packing-field="height" placeholder="0" />
+                    </label>
+                    <label>CBM
+                      <input type="number" name="packingCbm" min="0" step="0.001" data-packing-field="cbm" placeholder="0.000" />
+                    </label>
+                  </div>
+                  <div class="packing-form-actions">
+                    <button type="button" class="btn" data-packing-cancel>취소</button>
+                    <button type="button" class="btn primary" data-packing-create>생성</button>
+                  </div>
                 </div>
-                <div class="packing-form-actions">
-                  <button type="button" class="btn primary" data-packing-create>생성</button>
-                </div>
-              </div>
-            </section>
+              </section>
+            </div>
           </div>
           <section class="packing-items">
             <header class="packing-panel-header">

--- a/public/styles.css
+++ b/public/styles.css
@@ -200,13 +200,19 @@ input,select,textarea{padding:.5rem;border:1px solid var(--line);border-radius:6
 .expert-search[data-enabled="false"] .expert-search-fields input{color:#7780a6}
 
 /* Packing step */
-.packing-layout{display:grid;gap:1.25rem;margin-bottom:1.5rem}
+.packing-layout{display:flex;flex-direction:column;gap:1rem;margin-bottom:1.5rem}
+.packing-layout-actions{display:flex;justify-content:flex-end}
+.packing-layout-body{display:grid;gap:1.25rem;grid-template-columns:repeat(1,minmax(0,1fr))}
 @media (min-width:900px){
-  .packing-layout{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .packing-layout-body{grid-template-columns:repeat(2,minmax(0,1fr));align-items:flex-start}
 }
 .packing-panel{border:1px solid var(--line);border-radius:10px;padding:1rem;display:flex;flex-direction:column;gap:.75rem;background:#f7f9ff}
+.packing-panel-header{display:flex;justify-content:space-between;align-items:flex-start;gap:.5rem}
+.packing-panel-heading{display:flex;flex-direction:column;gap:.25rem}
 .packing-panel-header h4{margin:0;font-size:1.05rem;color:#122044}
-.packing-panel-header p{margin:.25rem 0 0;color:#566089;font-size:.85rem}
+.packing-panel-header p{margin:0;color:#566089;font-size:.85rem}
+.packing-panel-close{background:none;border:none;color:#4b5778;font-size:1.25rem;line-height:1;padding:.25rem;cursor:pointer;border-radius:6px}
+.packing-panel-close:hover{background:rgba(21,62,138,.1);color:#0f1b33}
 .packing-empty{margin:0;color:#6c779d;font-size:.9rem;padding:1rem;border:1px dashed #9aa6d6;border-radius:8px;background:#fff}
 .packing-card-list{list-style:none;margin:0;padding:0;display:grid;gap:.75rem}
 .packing-card{position:relative;border:1px solid #c9d3f2;border-radius:10px;padding:1rem;background:#fff;box-shadow:0 12px 24px rgba(16,31,68,.08);display:flex;flex-direction:column;gap:.65rem;overflow:hidden}
@@ -224,7 +230,7 @@ input,select,textarea{padding:.5rem;border:1px solid var(--line);border-radius:6
 .packing-card-details li span:last-child{font-variant-numeric:tabular-nums}
 .packing-form{display:flex;flex-direction:column;gap:.85rem}
 .packing-dimension-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.65rem}
-.packing-form-actions{display:flex;justify-content:flex-end}
+.packing-form-actions{display:flex;justify-content:flex-end;gap:.5rem}
 .packing-items{border:1px solid var(--line);border-radius:10px;padding:1rem;background:#fff;display:flex;flex-direction:column;gap:1rem}
 .packing-items-table table th{background:#f1f4ff;text-align:center}
 .packing-items-table table td{text-align:left}


### PR DESCRIPTION
## Summary
- hide the packing creation form behind a new top-right "팩킹 생성" trigger button and add cancel/close controls
- update the packing step state management so the form opens on demand and validations surface the new trigger when needed
- refresh the packing layout styling to accommodate the toggleable panel and new button placement

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d54c7d33bc8329926f8107b00970bc