### PR TITLE
Fix packing form visibility and layout adjustments

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -2067,6 +2067,13 @@ function openNewDialog() {
       cbm: packingStep.querySelector('[data-packing-field="cbm"]'),
     };
 
+    if (panel instanceof HTMLElement) {
+      panel.hidden = !state.formOpen;
+    }
+    if (openButton instanceof HTMLButtonElement) {
+      openButton.hidden = !!state.formOpen;
+    }
+
     const ensureDefaultName = () => {
       if (!(inputs.name instanceof HTMLInputElement)) return;
       if ((inputs.name.value ?? '').trim() === '') {
@@ -2245,6 +2252,13 @@ function openNewDialog() {
     };
 
     const openForm = ({ focusInput = true } = {}) => {
+      if (state.formOpen) {
+        if (focusInput && inputs.name instanceof HTMLInputElement) {
+          inputs.name.focus();
+          inputs.name.select();
+        }
+        return;
+      }
       state.formOpen = true;
       if (panel instanceof HTMLElement) {
         panel.hidden = false;
@@ -2385,17 +2399,20 @@ function openNewDialog() {
         createButton.addEventListener('click', handleCreate);
       }
       if (openButton instanceof HTMLButtonElement) {
-        openButton.addEventListener('click', () => {
+        openButton.addEventListener('click', (event) => {
+          event.preventDefault();
           openForm();
         });
       }
-      if (closeButton instanceof HTMLButtonElement) {
-        closeButton.addEventListener('click', () => {
+      if (closeButton) {
+        closeButton.addEventListener('click', (event) => {
+          event.preventDefault();
           closeForm({ focusTrigger: true });
         });
       }
-      if (cancelButton instanceof HTMLButtonElement) {
-        cancelButton.addEventListener('click', () => {
+      if (cancelButton) {
+        cancelButton.addEventListener('click', (event) => {
+          event.preventDefault();
           state.selection.clear();
           renderItemTable();
           closeForm({ resetFields: true, focusTrigger: true });

--- a/public/styles.css
+++ b/public/styles.css
@@ -200,13 +200,22 @@ input,select,textarea{padding:.5rem;border:1px solid var(--line);border-radius:6
 .expert-search[data-enabled="false"] .expert-search-fields input{color:#7780a6}
 
 /* Packing step */
-.packing-layout{display:flex;flex-direction:column;gap:1rem;margin-bottom:1.5rem}
+.step[data-packing-step]{display:grid;gap:1.5rem;grid-template-columns:minmax(0,1fr);align-items:flex-start}
+@media (min-width:900px){
+  .step[data-packing-step]{grid-template-columns:repeat(2,minmax(0,1fr))}
+}
+.packing-layout{display:flex;flex-direction:column;gap:1rem;margin-bottom:1.5rem;height:100%}
+@media (min-width:900px){
+  .packing-layout{margin-bottom:0}
+}
 .packing-layout-actions{display:flex;justify-content:flex-end}
 .packing-layout-body{display:grid;gap:1.25rem;grid-template-columns:repeat(1,minmax(0,1fr))}
 @media (min-width:900px){
   .packing-layout-body{grid-template-columns:repeat(2,minmax(0,1fr));align-items:flex-start}
 }
 .packing-panel{border:1px solid var(--line);border-radius:10px;padding:1rem;display:flex;flex-direction:column;gap:.75rem;background:#f7f9ff}
+.packing-panel[hidden]{display:none!important}
+.packing-layout-actions [data-packing-open][hidden]{display:none!important}
 .packing-panel-header{display:flex;justify-content:space-between;align-items:flex-start;gap:.5rem}
 .packing-panel-heading{display:flex;flex-direction:column;gap:.25rem}
 .packing-panel-header h4{margin:0;font-size:1.05rem;color:#122044}


### PR DESCRIPTION
## Summary
- hide the packing creation panel until the user clicks the "팩킹 생성" trigger and keep close/cancel buttons responsive
- synchronise the panel visibility state when the packing step is initialised to prevent duplicate openings
- adjust the packing step layout so the packing summary and item list share the space evenly on larger screens while keeping the form hidden when necessary

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5560119ac8329b283fee0e645c2ec