### PR TITLE
Restrict packing step visibility to final stage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -244,7 +244,14 @@
             </div>
           </div>
         </section>
-        <section class="step" data-step="12" data-step-title="팩킹리스트" data-packing-step>
+        <section
+          class="step"
+          data-step="12"
+          data-step-title="팩킹리스트"
+          data-packing-step
+          data-packing-visible="false"
+          aria-hidden="true"
+        >
           <div class="packing-layout">
             <div class="packing-layout-actions">
               <button type="button" class="btn primary" data-packing-open>팩킹 생성</button>

--- a/public/main.js
+++ b/public/main.js
@@ -2298,6 +2298,14 @@ function openNewDialog() {
     const applyVisibility = (isActive) => {
       packingStep.dataset.packingVisible = isActive ? 'true' : 'false';
       if (isActive) {
+        packingStep.removeAttribute('aria-hidden');
+      } else {
+        packingStep.setAttribute('aria-hidden', 'true');
+      }
+      if (typeof packingStep.toggleAttribute === 'function') {
+        packingStep.toggleAttribute('inert', !isActive);
+      }
+      if (isActive) {
         syncFormVisibility();
       } else {
         if (panel instanceof HTMLElement) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -201,6 +201,7 @@ input,select,textarea{padding:.5rem;border:1px solid var(--line);border-radius:6
 
 /* Packing step */
 .step[data-packing-step]{display:grid;gap:1.5rem;grid-template-columns:minmax(0,1fr);align-items:flex-start}
+.step[data-packing-step][data-packing-visible="false"]{display:none}
 @media (min-width:900px){
   .step[data-packing-step]{grid-template-columns:repeat(2,minmax(0,1fr))}
 }


### PR DESCRIPTION
## Summary
- hide the packing list step by default and only reveal it when the user reaches step 13
- update the packing step visibility logic to manage aria-hidden/inert attributes for accessibility

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5c5c4125c83298582b5c6de406499