### PR TITLE
Add standalone HTML bundle for offline usage

### DIFF
--- a/public/standalone.html
+++ b/public/standalone.html
@@ -1,0 +1,3624 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>수출 및 전략물자</title>
+  <meta name="description" content="수출 및 전략물자 - Standalone" />
+  <style>*{box-sizing:border-box}
+:root{
+  --blue:#153e8a;
+  --line:#d9d9d9;
+  --maxw:1200px;
+}
+html,body{height:100%}
+body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,Apple SD Gothic Neo,Noto Sans KR,sans-serif;line-height:1.45;color:#111;background:#f3f6fb}
+
+/* Topbar */
+.topbar{position:sticky;top:0;z-index:10;background:var(--blue);color:#fff;border-bottom:1px solid #0e2a5b}
+.topbar-inner{max-width:var(--maxw);margin:0 auto;display:flex;align-items:center;gap:.5rem;padding:.5rem .75rem;justify-content:flex-start}
+.tab{color:#fff;text-decoration:none;padding:.35rem .6rem;border-radius:2px;font-weight:600;display:inline-flex;align-items:center;gap:.35rem;background:transparent;border:1px solid transparent}
+.tab[aria-current="page"]{background:rgba(255,255,255,.15)}
+.menu{position:relative}
+.menu-toggle{border:none;background:transparent;font:inherit;color:inherit;cursor:pointer;display:inline-flex;align-items:center;gap:.35rem;appearance:none;-webkit-appearance:none}
+.menu-toggle::after{content:"▾";font-size:.7rem;line-height:1}
+.menu-toggle[data-active="true"],.menu.open .menu-toggle{background:rgba(255,255,255,.25)}
+.menu-panel{position:absolute;top:calc(100% + .35rem);left:0;min-width:190px;padding:.25rem 0;border:1px solid var(--blue);border-radius:6px;background:#fff;color:#0e2a5b;box-shadow:0 12px 24px rgba(4,20,61,.18);display:flex;flex-direction:column;z-index:20}
+.menu-panel[hidden]{display:none!important}
+.menu-item{display:flex;align-items:center;gap:.4rem;padding:.4rem .75rem;font-weight:500;font-size:.9rem;color:inherit;text-decoration:none;line-height:1.45}
+.menu-item:hover{background:rgba(21,62,138,.12)}
+.menu-item[aria-current="page"]{background:rgba(21,62,138,.18);font-weight:600}
+
+.btn.link{background:none;border:none;padding:0;color:#153e8a;font-weight:600;cursor:pointer;min-width:0}
+.btn.link:hover{background:none;text-decoration:underline;color:#0e2a5b}
+
+/* Content */
+.content{width:100%;margin:1.5rem 0;padding:1.5rem 2rem;min-height:65vh;background:#fff;display:flex;flex-direction:column;gap:1.5rem}
+@media (max-width:600px){
+  .content{width:calc(100% - 1.5rem);margin:1rem auto;padding:1.25rem;gap:1.25rem}
+}
+
+/* Cards / common */
+.card{border:1px solid var(--line);padding:1.25rem;background:#fff;border-radius:10px}
+h1,h2,h3{margin:0 0 .75rem}
+
+/* Search panel */
+.search-panel{display:grid;gap:1rem}
+.search-input input[type="text"]{width:100%;padding:.65rem .75rem;border:1px solid var(--line);border-radius:6px;background:#fff}
+.search-actions{display:flex;justify-content:flex-end}
+.search-actions .btn{width:100%}
+@media (min-width:600px){
+  .search-panel{grid-template-columns:minmax(0,1fr) auto;align-items:stretch}
+  .search-actions{justify-content:flex-start}
+  .search-actions .btn{width:auto}
+}
+
+.btn{display:inline-flex;align-items:center;justify-content:center;gap:.25rem;padding:.55rem .95rem;border:1px solid var(--line);background:#fff;color:inherit;font:inherit;border-radius:6px;cursor:pointer;text-decoration:none;transition:background .2s ease,border-color .2s ease,color .2s ease}
+.btn:hover{background:#f1f4f8}
+.btn:disabled{opacity:.6;cursor:not-allowed}
+.btn.primary{background:var(--blue);color:#fff;border-color:#0e2a5b}
+.btn.primary:hover{background:#0e2a5b}
+
+/* Home */
+.hero{display:flex;flex-direction:column;gap:1rem;align-items:flex-start}
+.hero-text p{margin:.5rem 0 0;color:#333}
+.hero .btn{align-self:stretch}
+@media (min-width:720px){
+  .hero{flex-direction:row;align-items:center;justify-content:space-between}
+  .hero-text{max-width:60%}
+  .hero .btn{align-self:center;width:auto}
+}
+
+.quick-guide h2{margin:0 0 .75rem}
+.guide-list{margin:0;padding-left:1.2rem;color:#444;line-height:1.6}
+.guide-list li+li{margin-top:.35rem}
+
+/* Export page */
+.page-header{display:flex;flex-direction:column;gap:1rem}
+.page-header h1{margin:0}
+.page-description{margin:.5rem 0 0;color:#444;font-size:.95rem}
+.header-actions{display:flex;gap:.5rem;align-items:center}
+@media (min-width:768px){
+  .page-header{flex-direction:row;align-items:flex-end;justify-content:space-between}
+  .header-actions{align-items:flex-end}
+}
+
+.header-actions{flex-wrap:wrap;justify-content:flex-end}
+
+/* Table */
+.table-card{display:flex;flex-direction:column;gap:1rem}
+.table-wrap{margin-top:0;overflow-x:visible}
+table{width:100%;border-collapse:collapse;table-layout:auto}
+.table-card table{min-width:0}
+th,td{border:1px solid var(--line);padding:.6rem .7rem;vertical-align:top;font-size:.85rem;line-height:1.45}
+th{background:#f5f5f5;text-align:left}
+tbody tr:hover{background:#fafcff}
+
+.export-table th{background:#e8eefc;text-align:center}
+.export-table col{width:auto!important}
+.export-table th{
+  white-space:normal;
+  line-height:1.4;
+  text-align:center;
+  font-size:.82rem;
+  padding:.65rem .5rem;
+}
+.export-table td{
+  white-space:normal;
+  text-align:left;
+  word-break:keep-all;
+  overflow-wrap:break-word;
+  font-size:.82rem;
+  padding:.6rem .5rem;
+}
+.export-table td[data-empty="true"]{color:#a3abbb;text-align:center;font-style:italic}
+.export-table td input[type="checkbox"]{width:16px;height:16px}
+.export-table td.error{color:#d23c3c;font-weight:600;text-align:center}
+.export-table .text-left{text-align:left}
+.export-table .text-right{text-align:right}
+.export-table .text-center{text-align:center}
+
+.export-table tbody tr td:first-child{font-weight:600;color:#0f1b33}
+.export-table tbody tr:nth-child(odd){background:#fbfdff}
+.export-table tbody tr:hover{background:#f1f5ff}
+.export-table tbody tr[data-draft="true"]{background:#fff5e6}
+.export-table tbody tr[data-draft="true"]:hover{background:#ffeacc}
+
+.export-table td[data-empty="true"]::after{content:""}
+
+@media (max-width:1200px){
+  .export-table th,.export-table td{font-size:.78rem;padding:.55rem .45rem}
+}
+
+@media (max-width:960px){
+  .page-header{gap:1.25rem}
+  .export-table th{font-size:.75rem}
+  .export-table td{font-size:.75rem}
+}
+
+@media (max-width:768px){
+  .table-card{padding:1rem}
+  .table-wrap{overflow-x:visible}
+  .export-table th,.export-table td{font-size:.72rem}
+}
+
+.table-footer{margin-top:1rem;display:flex;align-items:center;justify-content:space-between;gap:.75rem;flex-wrap:wrap}
+.result-count{margin:0;font-weight:600;color:#1f2a44}
+.pagination{display:flex;align-items:center;gap:.35rem}
+.pagination .page-info{font-weight:600;color:#153e8a;min-width:80px;text-align:center}
+.pagination .page-info[data-empty="true"]{color:#9397a3;font-weight:500}
+.page-btn{padding:.45rem .65rem;min-width:2.4rem;font-size:.85rem}
+.page-btn[disabled]{opacity:.45}
+
+/* Dialog */
+dialog{border:none;padding:0}
+dialog::backdrop{background:rgba(0,0,0,.35)}
+.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.75rem}
+.grid [data-span="full"]{grid-column:1 / -1}
+label{display:grid;gap:.3rem;font-weight:600}
+input,select,textarea{padding:.5rem;border:1px solid var(--line);border-radius:6px;font:inherit;resize:vertical}
+.checkbox-row{display:flex;align-items:center}
+.checkbox-row .checkbox-inline{display:inline-flex;align-items:center;gap:.45rem;font-weight:600}
+.checkbox-row .checkbox-inline input{width:18px;height:18px}
+.item-table{display:flex;flex-direction:column;gap:.75rem}
+.item-table .table-controls{display:flex;justify-content:flex-end;gap:.5rem}
+.item-table table th{text-align:center}
+.item-table table td{vertical-align:middle}
+.item-table tbody tr td:first-child{text-align:center}
+.item-table tbody input{width:100%}
+.item-table tbody input[type="number"]{text-align:right}
+.item-table tbody input[readonly]{background:#f7f8fb}
+.item-table tbody select{width:100%}
+.item-origin-field{display:flex;flex-direction:column;gap:.35rem}
+.item-summary{display:flex;justify-content:flex-end;gap:1.25rem;font-weight:600;color:#1f2a44}
+.item-summary div{display:flex;align-items:center;gap:.35rem}
+.item-summary strong{font-size:1rem;color:#153e8a}
+.step-container{display:flex;flex-direction:column;gap:1.25rem;margin-top:1rem}
+.step{display:block}
+.step[hidden]{display:none}
+.dialog-header{display:flex;flex-direction:column;gap:.35rem;margin-bottom:.5rem}
+.dialog-header h3{margin:0;font-size:1.2rem}
+.step-indicator{margin:0;font-size:.9rem;color:#52608f;font-weight:600}
+.step-title{margin:0;font-size:1.05rem;font-weight:700;color:#1f2a44}
+.dialog-actions{display:flex;justify-content:flex-end;gap:.5rem;margin-top:1.25rem;flex-wrap:wrap}
+.dialog-actions .btn{min-width:110px}
+.dialog-actions .btn.primary{order:3}
+.dialog-actions .btn[data-dialog-cancel]{order:4}
+.dialog-actions .btn[data-step-save]{order:2}
+.dialog-actions .btn[data-step-next]{order:1}
+.primary{background:var(--blue);color:#fff;border-color:#0e2a5b}
+
+.expert-search{display:flex;flex-direction:column;gap:.75rem;padding:1rem;border:1px solid #d2dbff;border-radius:10px;background:#f4f7ff}
+.grid .expert-search{grid-column:1 / -1}
+.expert-search label{font-weight:700;gap:.5rem}
+.expert-search-fields{display:flex;gap:.5rem;align-items:center}
+.expert-search-fields input[type="search"]{flex:1;min-width:0}
+.expert-search-results{list-style:none;margin:0;padding:0;border:1px solid #c6d3ff;border-radius:8px;max-height:220px;overflow:auto;background:#fff;box-shadow:0 6px 18px rgba(21,62,138,.12)}
+.expert-search-results[hidden]{display:none}
+.expert-search-option{display:flex;flex-direction:column;gap:.25rem;align-items:flex-start;width:100%;padding:.65rem .75rem;border:none;background:none;text-align:left;cursor:pointer;font:inherit;color:#122044}
+.expert-search-option:hover,.expert-search-option:focus{background:#eef3ff;outline:none}
+.expert-search-option-name{font-weight:600}
+.expert-search-option-desc{font-size:.82rem;color:#4e5a80}
+.expert-search-empty{padding:.75rem;color:#616f99;font-size:.85rem}
+.expert-search-selection{display:flex;align-items:center;gap:.5rem;font-size:.9rem;color:#2a3661}
+.expert-search-selection strong{color:#153e8a}
+.expert-search-helper{margin:0;font-size:.78rem;color:#5d6a98}
+.expert-search[data-enabled="false"] .expert-search-fields input,.expert-search[data-enabled="false"] .expert-search-fields button{background:#eef1f9;cursor:not-allowed}
+.expert-search[data-enabled="false"] .expert-search-fields input{color:#7780a6}
+
+/* Packing step */
+.step[data-packing-step]{display:grid;gap:1.5rem;grid-template-columns:minmax(0,1fr);align-items:flex-start}
+.step[data-packing-step][data-packing-visible="false"]{display:none}
+@media (min-width:900px){
+  .step[data-packing-step]{grid-template-columns:repeat(2,minmax(0,1fr))}
+}
+.packing-layout{display:flex;flex-direction:column;gap:1rem;margin-bottom:1.5rem;height:100%}
+@media (min-width:900px){
+  .packing-layout{margin-bottom:0}
+}
+.packing-layout-actions{display:flex;justify-content:flex-end}
+.packing-layout-body{display:grid;gap:1.25rem;grid-template-columns:repeat(1,minmax(0,1fr))}
+@media (min-width:900px){
+  .packing-layout-body{grid-template-columns:repeat(2,minmax(0,1fr));align-items:flex-start}
+}
+.packing-panel{border:1px solid var(--line);border-radius:10px;padding:1rem;display:flex;flex-direction:column;gap:.75rem;background:#f7f9ff}
+.packing-panel[hidden]{display:none!important}
+.packing-layout-actions [data-packing-open][hidden]{display:none!important}
+.packing-panel-header{display:flex;justify-content:space-between;align-items:flex-start;gap:.5rem}
+.packing-panel-heading{display:flex;flex-direction:column;gap:.25rem}
+.packing-panel-header h4{margin:0;font-size:1.05rem;color:#122044}
+.packing-panel-header p{margin:0;color:#566089;font-size:.85rem}
+.packing-panel-close{background:none;border:none;color:#4b5778;font-size:1.25rem;line-height:1;padding:.25rem;cursor:pointer;border-radius:6px}
+.packing-panel-close:hover{background:rgba(21,62,138,.1);color:#0f1b33}
+.packing-empty{margin:0;color:#6c779d;font-size:.9rem;padding:1rem;border:1px dashed #9aa6d6;border-radius:8px;background:#fff}
+.packing-card-list{list-style:none;margin:0;padding:0;display:grid;gap:.75rem}
+.packing-card{position:relative;border:1px solid #c9d3f2;border-radius:10px;padding:1rem;background:#fff;box-shadow:0 12px 24px rgba(16,31,68,.08);display:flex;flex-direction:column;gap:.65rem;overflow:hidden}
+.packing-card-title{font-weight:700;color:#0f1b33;font-size:1rem}
+.packing-card-meta{display:flex;flex-wrap:wrap;gap:.5rem;font-size:.8rem;color:#4b5778}
+.packing-card-meta span{display:inline-flex;align-items:center;gap:.25rem;padding:.25rem .5rem;background:#eef2ff;border-radius:999px}
+.packing-card-summary{display:flex;gap:1rem;font-size:.82rem;color:#1b2a56;font-weight:600}
+.packing-card-delete{position:absolute;top:.6rem;right:.6rem;background:none;border:none;color:#7080a9;font-size:1rem;cursor:pointer;line-height:1;padding:.25rem;border-radius:50%}
+.packing-card-delete:hover{background:rgba(21,62,138,.12);color:#0f1b33}
+.packing-card-details{position:absolute;inset:.5rem;border-radius:8px;background:rgba(17,23,46,.92);color:#fff;padding:1rem;display:flex;flex-direction:column;gap:.5rem;opacity:0;pointer-events:none;transition:opacity .2s ease}
+.packing-card:hover .packing-card-details,.packing-card:focus-within .packing-card-details{opacity:1}
+.packing-card-details h5{margin:0;font-size:.9rem}
+.packing-card-details ul{margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:.35rem;max-height:180px;overflow:auto}
+.packing-card-details li{display:flex;justify-content:space-between;gap:.75rem;font-size:.82rem}
+.packing-card-details li span:last-child{font-variant-numeric:tabular-nums}
+.packing-form{display:flex;flex-direction:column;gap:.85rem}
+.packing-dimension-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.65rem}
+.packing-form-actions{display:flex;justify-content:flex-end;gap:.5rem}
+.packing-items{border:1px solid var(--line);border-radius:10px;padding:1rem;background:#fff;display:flex;flex-direction:column;gap:1rem}
+.packing-items-table table th{background:#f1f4ff;text-align:center}
+.packing-items-table table td{text-align:left}
+.packing-items-table table th:first-child,.packing-items-table table td:first-child{text-align:center;width:60px}
+.packing-items-table table td input[type="checkbox"]{width:18px;height:18px}
+.packing-items-table tbody td:last-child{text-align:right}
+.packing-items-empty{padding:1rem;text-align:center;color:#6c779d;font-size:.9rem}
+@media (max-width:720px){
+  .packing-dimension-grid{grid-template-columns:repeat(1,minmax(0,1fr))}
+  .packing-card-details{font-size:.78rem}
+}
+
+/* Country select */
+.country-field{position:relative}
+.country-select{position:relative;width:100%}
+.country-select-trigger{display:flex;align-items:center;gap:.6rem;justify-content:flex-start;width:100%;padding:.55rem .75rem;border:1px solid var(--line);border-radius:6px;background:#fff;color:inherit;font:inherit;cursor:pointer;text-align:left;transition:border-color .2s ease,box-shadow .2s ease}
+.country-select-trigger::after{content:"▾";margin-left:auto;font-size:.75rem;color:#5a688a}
+.country-select-trigger[data-placeholder="true"]{color:#7a8194}
+.country-select-trigger:focus-visible{outline:3px solid rgba(21,62,138,.35);outline-offset:2px}
+.country-select.open .country-select-trigger{border-color:var(--blue);box-shadow:0 0 0 3px rgba(21,62,138,.15)}
+.country-select-flag{font-size:1.25rem;line-height:1}
+.country-select-text{display:flex;flex-direction:column;align-items:flex-start;gap:.15rem}
+.country-select-dial{font-size:.8rem;color:#5a688a}
+.country-select-trigger[data-placeholder="true"] .country-select-dial{display:none}
+.country-dropdown{position:absolute;top:calc(100% + .4rem);left:0;right:0;background:#fff;border:1px solid var(--line);border-radius:8px;box-shadow:0 18px 32px rgba(19,33,68,.18);display:flex;flex-direction:column;max-height:340px;z-index:30}
+.country-dropdown[hidden]{display:none!important}
+.country-search{position:sticky;top:0;padding:.45rem .75rem;border-bottom:1px solid var(--line);background:#fff;display:flex;align-items:center}
+.country-search::before{content:"\1F50D";margin-right:.5rem;font-size:1rem;color:#5a688a}
+.country-search input{flex:1;border:1px solid var(--line);border-radius:999px;padding:.45rem .75rem;font:inherit}
+.country-options{margin:0;padding:.25rem 0;list-style:none;overflow-y:auto;max-height:260px}
+.country-option{display:flex;align-items:center;gap:.65rem;width:100%;padding:.5rem .9rem;background:none;border:none;text-align:left;font:inherit;cursor:pointer;transition:background .15s ease}
+.country-option:hover,.country-option:focus{background:#f1f4ff;outline:none}
+.country-option[data-selected="true"]{background:#e8eefc}
+.country-option .country-flag{font-size:1.2rem;line-height:1}
+.country-option .country-info{display:flex;flex-direction:column;align-items:flex-start;gap:.15rem;flex:1;min-width:0}
+.country-option .country-name{font-weight:600}
+.country-option .country-en{font-size:.78rem;color:#6b7798}
+.country-option .country-dial{font-weight:600;color:#42518d}
+.country-empty{padding:.9rem 1rem;text-align:center;color:#7a8194;font-size:.9rem}
+
+@media (max-width:600px){
+  .country-dropdown{max-height:280px}
+  .country-options{max-height:210px}
+}
+
+/* Footer */
+.footer{width:100%;margin:0 0 2rem;padding:0 2rem;color:#555}
+@media (max-width:600px){
+  .footer{width:calc(100% - 1.5rem);margin:0 auto 1.5rem;padding:0}
+}
+</style>
+</head>
+<body>
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>수출 및 전략물자</title>
+  <meta name="description" content="수출 및 전략물자 - MVP" />
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <!-- 상단 탑바 -->
+  <header class="topbar" role="navigation" aria-label="상단 내비게이션">
+    <div class="topbar-inner">
+      <div class="menu" data-menu>
+        <button class="tab menu-toggle" type="button" data-menu-button aria-haspopup="true" aria-expanded="false" aria-controls="top-menu-panel">
+          수출 및 전략물자
+        </button>
+        <div class="menu-panel" id="top-menu-panel" role="menu" hidden>
+          <a class="menu-item" href="/dashboard" data-link role="menuitem">Dashboard</a>
+          <a class="menu-item" href="/export" data-link role="menuitem">수출현황</a>
+          <a class="menu-item" href="/expert-certificate" data-link role="menuitem">전략물자 전문판정서</a>
+          <a class="menu-item" href="/regulation" data-link role="menuitem">수출관리규정</a>
+          <a class="menu-item" href="/settings" data-link role="menuitem">설정</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <!-- 본문 -->
+  <main id="app" class="content" tabindex="-1" aria-live="polite">
+    <!-- 라우팅된 화면 -->
+  </main>
+
+  <!-- 신규등록 모달 -->
+  <dialog id="newExportDialog" aria-labelledby="newExportTitle">
+    <form id="newExportForm" method="dialog" class="card">
+      <header class="dialog-header">
+        <h3 id="newExportTitle">수출 신규등록</h3>
+        <p id="newExportStep" class="step-indicator" aria-live="polite">1 / 13</p>
+        <p id="newExportSection" class="step-title">수출목적</p>
+      </header>
+      <div class="step-container">
+        <section class="step" data-step="0" data-step-title="수출목적">
+          <div class="grid">
+            <label>수출유형
+              <select name="exportType" required>
+                <option value="">선택</option>
+                <option value="정상판매">정상판매</option>
+                <option value="A/S">A/S</option>
+                <option value="BMT">BMT</option>
+                <option value="장애교체">장애교체</option>
+                <option value="TEST">TEST</option>
+                <option value="Stock">Stock</option>
+                <option value="임대">임대</option>
+                <option value="유상임대">유상임대</option>
+                <option value="기타 장애교체">기타 장애교체</option>
+                <option value="기타 A/S">기타 A/S</option>
+                <option value="제조사샘플">제조사샘플</option>
+                <option value="개발용샘플">개발용샘플</option>
+                <option value="기타">기타</option>
+              </select>
+            </label>
+            <label data-export-type-detail hidden>기타 사유<input name="exportTypeDetail" placeholder="수출유형을 입력해주세요" /></label>
+            <label>프로젝트 명<input name="projectName" required placeholder="예: 프로젝트명" /></label>
+            <label>프로젝트 코드<input name="projectCode" required placeholder="예: PJT-2024-001" /></label>
+          </div>
+        </section>
+        <section class="step" data-step="1" data-step-title="전략물자 여부 확인">
+          <div class="grid">
+            <fieldset class="checkbox-group" data-required-group>
+              <legend>전략물자 여부</legend>
+              <label><input type="checkbox" value="전략물자 수출" data-strategic-option /> 전략물자 수출</label>
+              <label><input type="checkbox" value="일반수출" data-strategic-option /> 일반수출</label>
+              <input type="hidden" name="strategicFlag" data-strategic-value />
+            </fieldset>
+            <div class="expert-search" data-expert-search data-span="full">
+              <label>전략물자 전문판정 검색
+                <div class="expert-search-fields">
+                  <input type="search" placeholder="전문판정 키워드를 입력하세요" data-expert-input disabled aria-label="전략물자 전문판정 검색어" />
+                  <button type="button" class="btn" data-expert-search-btn disabled>검색</button>
+                </div>
+              </label>
+              <ul class="expert-search-results" data-expert-results hidden role="listbox" aria-label="전략물자 전문판정 검색 결과"></ul>
+              <div class="expert-search-selection" data-expert-selection>
+                <span>선택된 전문판정서</span>
+                <strong data-expert-selected-name>없음</strong>
+                <button type="button" class="btn link" data-expert-clear hidden>선택 해제</button>
+              </div>
+              <p class="expert-search-helper" data-expert-helper>
+                전략물자 수출을 선택하면 전문판정서를 검색 후 선택해야 다음 단계로 진행할 수 있습니다.
+              </p>
+              <input type="hidden" name="strategicExpertCertificate" data-expert-selected-value />
+            </div>
+          </div>
+        </section>
+        <section class="step" data-step="2" data-step-title="담당자 정보">
+          <div class="grid">
+            <label>이름<input name="managerName" required placeholder="예: 홍길동" /></label>
+            <label>부서<input name="managerDepartment" required placeholder="예: 영업팀" /></label>
+            <label>연락처<input name="managerPhone" required placeholder="예: 010-0000-0000" /></label>
+            <label>메일주소<input name="managerEmail" type="email" required placeholder="예: example@example.com" /></label>
+          </div>
+        </section>
+        <section class="step" data-step="3" data-step-title="수입자 정보">
+          <div class="grid">
+            <label>회사명<input name="importCompanyName" required placeholder="예: ABC Corp." /></label>
+            <label>주소<input name="importAddress" required placeholder="예: 서울특별시 ..." /></label>
+            <label class="country-field">국가
+              <div class="country-select" data-country-select>
+                <button type="button" class="country-select-trigger" data-country-toggle aria-haspopup="listbox" aria-expanded="false">
+                  <span class="country-select-flag" data-country-flag>🌐</span>
+                  <span class="country-select-text">
+                    <span data-country-label>국가를 선택하세요</span>
+                    <span class="country-select-dial" data-country-selected-dial></span>
+                  </span>
+                </button>
+                <div class="country-dropdown" data-country-menu hidden>
+                  <div class="country-search">
+                    <input type="search" placeholder="검색" data-country-search aria-label="국가 검색" autocomplete="off" />
+                  </div>
+                  <ul class="country-options" data-country-options role="listbox"></ul>
+                </div>
+                <input type="hidden" name="importCountry" data-country-value data-required-hidden data-required-message="국가를 선택해주세요." data-target-selector="[data-country-toggle]" />
+              </div>
+            </label>
+            <label>국가번호<input name="importCountryCode" required readonly data-country-code placeholder="예: +82" /></label>
+            <label>전화번호<input name="importPhone" required placeholder="예: 02-000-0000" /></label>
+            <label>이름<input name="importContactName" required placeholder="예: John Doe" /></label>
+            <label>연락처<input name="importContactPhone" required placeholder="예: +82-10-0000-0000" /></label>
+            <label>이메일<input name="importEmail" type="email" required placeholder="예: contact@example.com" /></label>
+            <label>기타<textarea name="importEtc" rows="3" placeholder="추가 정보를 입력해주세요"></textarea></label>
+          </div>
+        </section>
+        <section class="step" data-step="4" data-step-title="Notify Party (착하통지처)">
+          <div class="grid">
+            <div data-span="full" class="checkbox-row">
+              <label class="checkbox-inline"><input type="checkbox" name="notifySameAsImporter" data-notify-copy /> 수입자와 동일</label>
+            </div>
+            <label>회사명<input name="notifyCompanyName" required placeholder="예: ABC Corp." /></label>
+            <label>주소<input name="notifyAddress" required placeholder="예: 서울특별시 ..." /></label>
+            <label>국가
+              <select name="notifyCountry" required data-country-select-simple data-code-target="notifyCountryCode">
+                <option value="">선택</option>
+              </select>
+            </label>
+            <label>국가번호<input name="notifyCountryCode" required readonly placeholder="예: +82" /></label>
+            <label>전화번호<input name="notifyPhone" required placeholder="예: 02-000-0000" /></label>
+            <label>이름<input name="notifyContactName" required placeholder="예: John Doe" /></label>
+            <label>연락처<input name="notifyContactPhone" required placeholder="예: +82-10-0000-0000" /></label>
+            <label>이메일<input name="notifyEmail" type="email" required placeholder="예: contact@example.com" /></label>
+            <label>기타<textarea name="notifyEtc" rows="3" placeholder="추가 정보를 입력해주세요"></textarea></label>
+          </div>
+        </section>
+        <section class="step" data-step="5" data-step-title="출발국가 및 최종 배송국가">
+          <div class="grid">
+            <label>출발국가
+              <select name="originCountry" required data-country-select-simple>
+                <option value="">선택</option>
+              </select>
+            </label>
+            <label>최종 배송국가
+              <select name="destinationCountry" required data-country-select-simple>
+                <option value="">선택</option>
+              </select>
+            </label>
+          </div>
+        </section>
+        <section class="step" data-step="6" data-step-title="발송일자">
+          <div class="grid">
+            <label data-span="full">발송일자<input name="dispatchDate" type="date" required aria-label="발송일자" /></label>
+          </div>
+        </section>
+        <section class="step" data-step="7" data-step-title="운송수단">
+          <div class="grid">
+            <label>운송수단
+              <select name="transportMode" required>
+                <option value="">선택</option>
+                <option value="항공">항공</option>
+                <option value="해상">해상</option>
+                <option value="육로">육로</option>
+                <option value="기타">기타</option>
+              </select>
+            </label>
+            <label data-transport-detail hidden>기타 사유<input name="transportOther" placeholder="운송수단을 입력해주세요" /></label>
+          </div>
+        </section>
+        <section class="step" data-step="8" data-step-title="선적예정일">
+          <div class="grid">
+            <label data-span="full">선적예정일<input name="loadingDate" type="date" required aria-label="선적예정일" /></label>
+          </div>
+        </section>
+        <section class="step" data-step="9" data-step-title="배송조건 (Incoterms)">
+          <div class="grid">
+            <label>배송조건 (Incoterms)
+              <select name="incoterms" required>
+                <option value="">선택</option>
+                <option value="EXW">EXW</option>
+                <option value="FCA">FCA</option>
+                <option value="FAS">FAS</option>
+                <option value="FOB">FOB</option>
+                <option value="CFR">CFR</option>
+                <option value="CIF">CIF</option>
+                <option value="CPT">CPT</option>
+                <option value="CIP">CIP</option>
+                <option value="DAP">DAP</option>
+                <option value="DPU">DPU</option>
+                <option value="DDP">DDP</option>
+                <option value="기타">기타</option>
+              </select>
+            </label>
+            <label data-incoterms-detail hidden>기타 조건<input name="incotermsOther" placeholder="배송조건을 입력해주세요" /></label>
+          </div>
+        </section>
+        <section class="step" data-step="10" data-step-title="결제조건">
+          <div class="grid">
+            <label data-span="full">결제조건<input name="paymentTerms" required placeholder="예: 선지급 50%, 납품 후 50%" /></label>
+          </div>
+        </section>
+        <section class="step" data-step="11" data-step-title="품목정보" data-items-step>
+          <div class="item-table">
+            <div class="table-controls">
+              <button type="button" class="btn" data-item-add>행 추가</button>
+              <button type="button" class="btn" data-item-remove>행 삭제</button>
+            </div>
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">선택</th>
+                  <th scope="col">NO</th>
+                  <th scope="col">품명</th>
+                  <th scope="col">품목구분</th>
+                  <th scope="col">수량</th>
+                  <th scope="col">통화</th>
+                  <th scope="col">단가</th>
+                  <th scope="col">총액</th>
+                  <th scope="col">생산국</th>
+                </tr>
+              </thead>
+              <tbody data-item-rows></tbody>
+            </table>
+            <div class="item-summary" data-item-summary>
+              <div>총 수량 <strong data-item-qty-sum>0</strong></div>
+              <div>총액 <strong data-item-total-sum>0</strong></div>
+            </div>
+          </div>
+        </section>
+        <section
+          class="step"
+          data-step="12"
+          data-step-title="팩킹리스트"
+          data-packing-step
+          data-packing-visible="false"
+          aria-hidden="true"
+        >
+          <div class="packing-layout">
+            <div class="packing-layout-actions">
+              <button type="button" class="btn primary" data-packing-open>팩킹 생성</button>
+            </div>
+            <div class="packing-layout-body">
+              <section class="packing-panel">
+                <header class="packing-panel-header">
+                  <div class="packing-panel-heading">
+                    <h4>팩킹정보</h4>
+                    <p>생성된 Packing의 요약을 확인하세요.</p>
+                  </div>
+                </header>
+                <p class="packing-empty" data-packing-empty>등록된 팩킹이 없습니다. 우측 상단의 버튼을 눌러 팩킹을 생성해주세요.</p>
+                <ul class="packing-card-list" data-packing-list></ul>
+              </section>
+              <section class="packing-panel packing-create-panel" data-packing-panel hidden>
+                <header class="packing-panel-header">
+                  <div class="packing-panel-heading">
+                    <h4>팩킹 생성</h4>
+                    <p>Packing 정보를 입력해주세요.</p>
+                  </div>
+                  <button type="button" class="packing-panel-close" data-packing-close aria-label="팩킹 생성 닫기">×</button>
+                </header>
+                <div class="packing-form" data-packing-form>
+                  <label>팩킹명
+                    <input type="text" name="packingName" data-packing-field="name" placeholder="예: Packing 01" />
+                  </label>
+                  <div class="packing-dimension-grid">
+                    <label>Length (cm)
+                      <input type="number" name="packingLength" min="0" step="0.1" data-packing-field="length" placeholder="0" />
+                    </label>
+                    <label>Width (cm)
+                      <input type="number" name="packingWidth" min="0" step="0.1" data-packing-field="width" placeholder="0" />
+                    </label>
+                    <label>Height (cm)
+                      <input type="number" name="packingHeight" min="0" step="0.1" data-packing-field="height" placeholder="0" />
+                    </label>
+                    <label>CBM
+                      <input type="number" name="packingCbm" min="0" step="0.001" data-packing-field="cbm" placeholder="0.000" />
+                    </label>
+                  </div>
+                  <div class="packing-form-actions">
+                    <button type="button" class="btn" data-packing-cancel>취소</button>
+                    <button type="button" class="btn primary" data-packing-create>생성</button>
+                  </div>
+                </div>
+              </section>
+            </div>
+          </div>
+          <section class="packing-items">
+            <header class="packing-panel-header">
+              <h4>품목정보</h4>
+              <p>팩킹에 포함할 품목을 선택해주세요.</p>
+            </header>
+            <div class="packing-items-table">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col"><input type="checkbox" data-packing-select-all aria-label="전체 선택" /></th>
+                    <th scope="col">NO</th>
+                    <th scope="col">품명</th>
+                    <th scope="col">품목구분</th>
+                    <th scope="col">수량</th>
+                  </tr>
+                </thead>
+                <tbody data-packing-items-body></tbody>
+              </table>
+            </div>
+          </section>
+        </section>
+      </div>
+      <menu class="dialog-actions">
+        <button type="button" data-step-prev class="btn">이전 단계</button>
+        <button type="button" data-step-next class="btn">다음 단계</button>
+        <button type="button" data-step-save class="btn">임시저장</button>
+        <button type="submit" data-step-complete class="btn primary" disabled>완료</button>
+        <button type="button" data-dialog-cancel class="btn">취소</button>
+      </menu>
+    </form>
+  </dialog>
+
+  <footer class='footer'>
+    <small>© <span id="year"></span></small>
+  </footer>
+
+  
+  <script>// 작은 라우터 + API 연동 + 모달 신규등록
+
+const $ = (sel, root = document) => root.querySelector(sel);
+const $$ = (sel, root = document) => [...root.querySelectorAll(sel)];
+const app = $("#app");
+
+const PAGE_SIZE = 20;
+
+// Standalone fetch polyfill for offline usage
+const originalFetch = window.fetch ? window.fetch.bind(window) : null;
+const __standaloneStore = (() => {
+  const now = Date.now();
+  const baseDay = 86_400_000;
+  const sampleRows = [
+    {
+      id: 1,
+      item: "반도체 웨이퍼",
+      qty: 1000,
+      unitPrice: 2.5,
+      country: "KR",
+      status: "완료",
+      createdAt: now - baseDay * 5,
+      shipmentType: "정상판매",
+      projectName: "차세대 반도체 라인 구축",
+      projectCode: "PJT-2024-001",
+      client: "삼성전자",
+      endUser: "삼성전자",
+      department: "영업1팀",
+      manager: "김민수",
+      plStatus: "제출",
+      invoiceStatus: "제출",
+      permitStatus: "완료",
+      declarationStatus: "완료",
+      usageStatus: "확인",
+      blStatus: "발급",
+      fileNote: "관련 서류 업로드 완료",
+      note: "우수 거래처"
+    },
+    {
+      id: 2,
+      item: "제어보드",
+      qty: 120,
+      unitPrice: 49.9,
+      country: "US",
+      status: "진행",
+      createdAt: now - baseDay * 2,
+      shipmentType: "BMT",
+      projectName: "미국 BMT 공급",
+      projectCode: "PJT-2024-014",
+      client: "Delta Corp.",
+      endUser: "Delta Corp.",
+      department: "해외영업팀",
+      manager: "박지훈",
+      plStatus: "작성중",
+      invoiceStatus: "대기",
+      permitStatus: "진행",
+      declarationStatus: "대기",
+      usageStatus: "확인중",
+      blStatus: "준비",
+      fileNote: "샘플 계약",
+      note: "미국 인증 진행중"
+    },
+    {
+      id: 3,
+      item: "센서 모듈",
+      qty: 500,
+      unitPrice: 8.2,
+      country: "JP",
+      status: "대기",
+      createdAt: now - baseDay,
+      shipmentType: "정상판매",
+      projectName: "센서 공급 3차",
+      projectCode: "PJT-2024-021",
+      client: "Nippon Tech",
+      endUser: "Nippon Tech",
+      department: "영업2팀",
+      manager: "이서연",
+      plStatus: "준비",
+      invoiceStatus: "준비",
+      permitStatus: "검토",
+      declarationStatus: "대기",
+      usageStatus: "확인중",
+      blStatus: "대기",
+      fileNote: "-",
+      note: "긴급 대응"
+    },
+    {
+      id: 4,
+      item: "공정용 소프트",
+      qty: 20,
+      unitPrice: 999,
+      country: "DE",
+      status: "진행",
+      createdAt: now - 3_600_000,
+      shipmentType: "A/S",
+      projectName: "독일 공정 지원",
+      projectCode: "PJT-2024-032",
+      client: "Muller AG",
+      endUser: "Muller AG",
+      department: "기술영업팀",
+      manager: "최유진",
+      plStatus: "작성중",
+      invoiceStatus: "작성중",
+      permitStatus: "접수",
+      declarationStatus: "대기",
+      usageStatus: "검토",
+      blStatus: "준비",
+      fileNote: "원격 설치 예정",
+      note: ""
+    }
+  ];
+
+  let seq = sampleRows.reduce((acc, row) => {
+    const id = Number(row && row.id ? row.id : 0);
+    return Number.isFinite(id) && id > acc ? id : acc;
+  }, 0) + 1;
+
+  const exportsData = sampleRows.slice();
+
+  const toNumber = (value) => {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : 0;
+  };
+
+  const toUpper = (value) => (value ? String(value).toUpperCase() : "");
+
+  const respondJson = (data, status = 200) =>
+    Promise.resolve(
+      new Response(JSON.stringify(data), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+  const list = ({ page = 1, pageSize = PAGE_SIZE, query = "" } = {}) => {
+    const normalizedQuery = String(query || "").trim().toLowerCase();
+    const size = Math.min(Math.max(Number(pageSize) || PAGE_SIZE, 1), 100);
+    const sorted = exportsData.slice().sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+    const filtered = normalizedQuery
+      ? sorted.filter((row) => {
+          const values = [
+            row.item,
+            row.country,
+            row.status,
+            row.projectName,
+            row.projectCode,
+            row.client,
+            row.manager,
+          ];
+          return values.some((value) =>
+            value ? String(value).toLowerCase().includes(normalizedQuery) : false
+          );
+        })
+      : sorted;
+    const totalCount = filtered.length;
+    const totalPages = totalCount === 0 ? 0 : Math.ceil(totalCount / size);
+    const safePage = totalPages === 0 ? 1 : Math.max(1, Math.min(Number(page) || 1, totalPages));
+    const start = totalPages === 0 ? 0 : (safePage - 1) * size;
+    const items = filtered.slice(start, start + size);
+    return { ok: true, totalCount, totalPages, page: safePage, pageSize: size, items };
+  };
+
+  const create = (payload = {}) => {
+    const items = Array.isArray(payload.items) ? payload.items : [];
+    const firstItem = items.length ? items[0] : {};
+    const row = {
+      id: seq++,
+      item: payload.item || firstItem.name || "",
+      qty: toNumber(payload.qty ?? firstItem.quantity),
+      unitPrice: toNumber(payload.unitPrice ?? firstItem.unitPrice),
+      country: toUpper(
+        payload.country ||
+          payload.destinationCountry ||
+          payload.importCountry ||
+          (firstItem.origin || "")
+      ),
+      status: payload.status || "대기",
+      createdAt: Date.now(),
+      shipmentType: payload.shipmentType || payload.exportType || "",
+      projectName: payload.projectName || payload.projectNameDisplay || "",
+      projectCode: payload.projectCode || payload.projectCodeDisplay || "",
+      client: payload.client || payload.importCompanyName || "",
+      endUser: payload.endUser || "",
+      department:
+        payload.department || payload.managerDepartment || (payload.requester?.department ?? ""),
+      manager: payload.manager || payload.managerName || (payload.requester?.name ?? ""),
+      managerEmail: payload.managerEmail || (payload.requester?.email ?? ""),
+      contactPhone: payload.contactPhone || (payload.requester?.phone ?? ""),
+      plStatus: payload.plStatus || "",
+      invoiceStatus: payload.invoiceStatus || "",
+      permitStatus: payload.permitStatus || "",
+      declarationStatus: payload.declarationStatus || "",
+      usageStatus: payload.usageStatus || "",
+      blStatus: payload.blStatus || "",
+      fileNote: payload.fileNote || "",
+      note: payload.note || "",
+    };
+    exportsData.push(row);
+    return { ok: true, item: row };
+  };
+
+  const handleFetch = async (input, init = {}) => {
+    const method = (init.method || (input && input.method) || 'GET').toUpperCase();
+    const url = typeof input === 'string' ? input : input.url;
+    const targetUrl = new URL(url, window.location.origin);
+
+    if (method === 'GET') {
+      const params = {
+        page: Number(targetUrl.searchParams.get('page')) || 1,
+        pageSize: Number(targetUrl.searchParams.get('pageSize')) || PAGE_SIZE,
+        query: targetUrl.searchParams.get('query') || '',
+      };
+      return respondJson(list(params));
+    }
+
+    if (method === 'POST') {
+      const bodyText = init.body
+        ? typeof init.body === 'string'
+          ? init.body
+          : await new Response(init.body).text()
+        : typeof input !== 'string' && input.body
+        ? await input.text()
+        : '{}';
+      let payload;
+      try {
+        payload = JSON.parse(bodyText || '{}');
+      } catch (error) {
+        return respondJson({ ok: false, error: '잘못된 요청 본문' }, 400);
+      }
+      if (!payload || (!payload.item && !(payload.items && payload.items.length))) {
+        return respondJson({ ok: false, error: '필수 항목 누락' }, 400);
+      }
+      const result = create(payload);
+      return respondJson(result, 201);
+    }
+
+    return respondJson({ ok: false, error: '지원하지 않는 메서드' }, 405);
+  };
+
+  return {
+    async fetch(input, init) {
+      const url = typeof input === 'string' ? input : input?.url || '';
+      if (url.includes('/api/exports')) {
+        return handleFetch(input, init || {});
+      }
+      if (originalFetch) {
+        return originalFetch(input, init);
+      }
+      return Promise.reject(new Error('네트워크 요청을 수행할 수 없습니다.'));
+    },
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.fetch = (input, init) => __standaloneStore.fetch(input, init);
+}
+
+const EXPORT_TABLE_COLSPAN = 22;
+let currentPage = 1;
+let currentQuery = "";
+let lastMeta = { totalPages: 0, totalCount: 0, pageSize: PAGE_SIZE };
+let lastServerMeta = { totalPages: 0, totalCount: 0, pageSize: PAGE_SIZE };
+let lastFetchedItems = [];
+const draftEntries = [];
+let draftSeq = -1;
+let selectionHandlersInitialized = false;
+
+const toFlagEmoji = (countryCode = "") => {
+  if (typeof countryCode !== "string" || countryCode.length !== 2) return "🏳";
+  const upper = countryCode.toUpperCase();
+  const codePoints = [...upper].map((char) => 127397 + char.charCodeAt(0));
+  return String.fromCodePoint(...codePoints);
+};
+
+const COUNTRY_DATA = [
+  { ko: "대한민국", en: "South Korea", iso2: "KR", dialCode: "+82" },
+  { ko: "미국", en: "United States", iso2: "US", dialCode: "+1" },
+  { ko: "일본", en: "Japan", iso2: "JP", dialCode: "+81" },
+  { ko: "중국", en: "China", iso2: "CN", dialCode: "+86" },
+  { ko: "캐나다", en: "Canada", iso2: "CA", dialCode: "+1" },
+  { ko: "멕시코", en: "Mexico", iso2: "MX", dialCode: "+52" },
+  { ko: "브라질", en: "Brazil", iso2: "BR", dialCode: "+55" },
+  { ko: "아르헨티나", en: "Argentina", iso2: "AR", dialCode: "+54" },
+  { ko: "칠레", en: "Chile", iso2: "CL", dialCode: "+56" },
+  { ko: "페루", en: "Peru", iso2: "PE", dialCode: "+51" },
+  { ko: "콜롬비아", en: "Colombia", iso2: "CO", dialCode: "+57" },
+  { ko: "영국", en: "United Kingdom", iso2: "GB", dialCode: "+44" },
+  { ko: "프랑스", en: "France", iso2: "FR", dialCode: "+33" },
+  { ko: "이탈리아", en: "Italy", iso2: "IT", dialCode: "+39" },
+  { ko: "스페인", en: "Spain", iso2: "ES", dialCode: "+34" },
+  { ko: "독일", en: "Germany", iso2: "DE", dialCode: "+49" },
+  { ko: "네덜란드", en: "Netherlands", iso2: "NL", dialCode: "+31" },
+  { ko: "벨기에", en: "Belgium", iso2: "BE", dialCode: "+32" },
+  { ko: "룩셈부르크", en: "Luxembourg", iso2: "LU", dialCode: "+352" },
+  { ko: "스위스", en: "Switzerland", iso2: "CH", dialCode: "+41" },
+  { ko: "오스트리아", en: "Austria", iso2: "AT", dialCode: "+43" },
+  { ko: "덴마크", en: "Denmark", iso2: "DK", dialCode: "+45" },
+  { ko: "스웨덴", en: "Sweden", iso2: "SE", dialCode: "+46" },
+  { ko: "노르웨이", en: "Norway", iso2: "NO", dialCode: "+47" },
+  { ko: "핀란드", en: "Finland", iso2: "FI", dialCode: "+358" },
+  { ko: "포르투갈", en: "Portugal", iso2: "PT", dialCode: "+351" },
+  { ko: "그리스", en: "Greece", iso2: "GR", dialCode: "+30" },
+  { ko: "체코", en: "Czechia", iso2: "CZ", dialCode: "+420" },
+  { ko: "헝가리", en: "Hungary", iso2: "HU", dialCode: "+36" },
+  { ko: "폴란드", en: "Poland", iso2: "PL", dialCode: "+48" },
+  { ko: "루마니아", en: "Romania", iso2: "RO", dialCode: "+40" },
+  { ko: "불가리아", en: "Bulgaria", iso2: "BG", dialCode: "+359" },
+  { ko: "슬로바키아", en: "Slovakia", iso2: "SK", dialCode: "+421" },
+  { ko: "슬로베니아", en: "Slovenia", iso2: "SI", dialCode: "+386" },
+  { ko: "크로아티아", en: "Croatia", iso2: "HR", dialCode: "+385" },
+  { ko: "라트비아", en: "Latvia", iso2: "LV", dialCode: "+371" },
+  { ko: "리투아니아", en: "Lithuania", iso2: "LT", dialCode: "+370" },
+  { ko: "에스토니아", en: "Estonia", iso2: "EE", dialCode: "+372" },
+  { ko: "아일랜드", en: "Ireland", iso2: "IE", dialCode: "+353" },
+  { ko: "아이슬란드", en: "Iceland", iso2: "IS", dialCode: "+354" },
+  { ko: "우크라이나", en: "Ukraine", iso2: "UA", dialCode: "+380" },
+  { ko: "러시아", en: "Russia", iso2: "RU", dialCode: "+7" },
+  { ko: "터키", en: "Turkey", iso2: "TR", dialCode: "+90" },
+  { ko: "이스라엘", en: "Israel", iso2: "IL", dialCode: "+972" },
+  { ko: "아랍에미리트", en: "United Arab Emirates", iso2: "AE", dialCode: "+971" },
+  { ko: "사우디아라비아", en: "Saudi Arabia", iso2: "SA", dialCode: "+966" },
+  { ko: "카타르", en: "Qatar", iso2: "QA", dialCode: "+974" },
+  { ko: "쿠웨이트", en: "Kuwait", iso2: "KW", dialCode: "+965" },
+  { ko: "바레인", en: "Bahrain", iso2: "BH", dialCode: "+973" },
+  { ko: "오만", en: "Oman", iso2: "OM", dialCode: "+968" },
+  { ko: "요르단", en: "Jordan", iso2: "JO", dialCode: "+962" },
+  { ko: "이집트", en: "Egypt", iso2: "EG", dialCode: "+20" },
+  { ko: "이란", en: "Iran", iso2: "IR", dialCode: "+98" },
+  { ko: "이라크", en: "Iraq", iso2: "IQ", dialCode: "+964" },
+  { ko: "파키스탄", en: "Pakistan", iso2: "PK", dialCode: "+92" },
+  { ko: "방글라데시", en: "Bangladesh", iso2: "BD", dialCode: "+880" },
+  { ko: "인도", en: "India", iso2: "IN", dialCode: "+91" },
+  { ko: "스리랑카", en: "Sri Lanka", iso2: "LK", dialCode: "+94" },
+  { ko: "네팔", en: "Nepal", iso2: "NP", dialCode: "+977" },
+  { ko: "몽골", en: "Mongolia", iso2: "MN", dialCode: "+976" },
+  { ko: "카자흐스탄", en: "Kazakhstan", iso2: "KZ", dialCode: "+7" },
+  { ko: "우즈베키스탄", en: "Uzbekistan", iso2: "UZ", dialCode: "+998" },
+  { ko: "베트남", en: "Vietnam", iso2: "VN", dialCode: "+84" },
+  { ko: "태국", en: "Thailand", iso2: "TH", dialCode: "+66" },
+  { ko: "말레이시아", en: "Malaysia", iso2: "MY", dialCode: "+60" },
+  { ko: "싱가포르", en: "Singapore", iso2: "SG", dialCode: "+65" },
+  { ko: "인도네시아", en: "Indonesia", iso2: "ID", dialCode: "+62" },
+  { ko: "필리핀", en: "Philippines", iso2: "PH", dialCode: "+63" },
+  { ko: "캄보디아", en: "Cambodia", iso2: "KH", dialCode: "+855" },
+  { ko: "라오스", en: "Laos", iso2: "LA", dialCode: "+856" },
+  { ko: "미얀마", en: "Myanmar", iso2: "MM", dialCode: "+95" },
+  { ko: "브루나이", en: "Brunei", iso2: "BN", dialCode: "+673" },
+  { ko: "홍콩", en: "Hong Kong", iso2: "HK", dialCode: "+852" },
+  { ko: "마카오", en: "Macau", iso2: "MO", dialCode: "+853" },
+  { ko: "대만", en: "Taiwan", iso2: "TW", dialCode: "+886" },
+  { ko: "호주", en: "Australia", iso2: "AU", dialCode: "+61" },
+  { ko: "뉴질랜드", en: "New Zealand", iso2: "NZ", dialCode: "+64" },
+  { ko: "사모아", en: "Samoa", iso2: "WS", dialCode: "+685" },
+  { ko: "피지", en: "Fiji", iso2: "FJ", dialCode: "+679" },
+  { ko: "파푸아뉴기니", en: "Papua New Guinea", iso2: "PG", dialCode: "+675" },
+  { ko: "남아프리카공화국", en: "South Africa", iso2: "ZA", dialCode: "+27" },
+  { ko: "나이지리아", en: "Nigeria", iso2: "NG", dialCode: "+234" },
+  { ko: "케냐", en: "Kenya", iso2: "KE", dialCode: "+254" },
+  { ko: "모로코", en: "Morocco", iso2: "MA", dialCode: "+212" },
+  { ko: "알제리", en: "Algeria", iso2: "DZ", dialCode: "+213" },
+  { ko: "튀니지", en: "Tunisia", iso2: "TN", dialCode: "+216" },
+  { ko: "에티오피아", en: "Ethiopia", iso2: "ET", dialCode: "+251" },
+  { ko: "가나", en: "Ghana", iso2: "GH", dialCode: "+233" },
+  { ko: "탄자니아", en: "Tanzania", iso2: "TZ", dialCode: "+255" },
+  { ko: "앙골라", en: "Angola", iso2: "AO", dialCode: "+244" },
+  { ko: "짐바브웨", en: "Zimbabwe", iso2: "ZW", dialCode: "+263" },
+  { ko: "우간다", en: "Uganda", iso2: "UG", dialCode: "+256" },
+  { ko: "보츠와나", en: "Botswana", iso2: "BW", dialCode: "+267" },
+  { ko: "잠비아", en: "Zambia", iso2: "ZM", dialCode: "+260" },
+  { ko: "세네갈", en: "Senegal", iso2: "SN", dialCode: "+221" },
+  { ko: "코트디부아르", en: "Ivory Coast", iso2: "CI", dialCode: "+225" },
+  { ko: "카메룬", en: "Cameroon", iso2: "CM", dialCode: "+237" },
+  { ko: "수단", en: "Sudan", iso2: "SD", dialCode: "+249" },
+  { ko: "카보베르데", en: "Cape Verde", iso2: "CV", dialCode: "+238" },
+  { ko: "마다가스카르", en: "Madagascar", iso2: "MG", dialCode: "+261" },
+  { ko: "모리셔스", en: "Mauritius", iso2: "MU", dialCode: "+230" },
+  { ko: "트리니다드토바고", en: "Trinidad and Tobago", iso2: "TT", dialCode: "+1" },
+  { ko: "쿠바", en: "Cuba", iso2: "CU", dialCode: "+53" },
+  { ko: "도미니카공화국", en: "Dominican Republic", iso2: "DO", dialCode: "+1" },
+  { ko: "자메이카", en: "Jamaica", iso2: "JM", dialCode: "+1" },
+  { ko: "파나마", en: "Panama", iso2: "PA", dialCode: "+507" },
+  { ko: "코스타리카", en: "Costa Rica", iso2: "CR", dialCode: "+506" },
+  { ko: "파라과이", en: "Paraguay", iso2: "PY", dialCode: "+595" },
+  { ko: "우루과이", en: "Uruguay", iso2: "UY", dialCode: "+598" },
+  { ko: "볼리비아", en: "Bolivia", iso2: "BO", dialCode: "+591" },
+  { ko: "베네수엘라", en: "Venezuela", iso2: "VE", dialCode: "+58" }
+];
+
+const COUNTRY_LIST = COUNTRY_DATA.map((item) => {
+  const iso2 = item.iso2.toUpperCase();
+  const dial = item.dialCode.startsWith("+") ? item.dialCode : `+${item.dialCode}`;
+  const searchValue = [item.ko, item.en, iso2, dial, dial.replace(/[+\s-]/g, ""), item.ko.replace(/\s/g, ""), item.en.replace(/\s/g, "")]
+    .join(" ")
+    .toLowerCase();
+  return {
+    name: item.ko,
+    english: item.en,
+    iso2,
+    dialCode: dial,
+    flag: toFlagEmoji(iso2),
+    searchValue,
+  };
+}).sort((a, b) => a.name.localeCompare(b.name, "ko-KR"));
+
+const EXPERT_CERTIFICATES = [
+  {
+    id: "cert-001",
+    name: "레이더 시스템 전문판정서",
+    description: "지상 감시 레이더 장비 판정",
+    keywords: ["레이더", "감시", "지상"],
+  },
+  {
+    id: "cert-002",
+    name: "위성통신 모듈 전문판정서",
+    description: "위성 통신용 RF 모듈 판정",
+    keywords: ["위성", "통신", "RF"],
+  },
+  {
+    id: "cert-003",
+    name: "암호장비 전문판정서",
+    description: "보안 암호장비 및 소프트웨어",
+    keywords: ["암호", "보안", "소프트웨어"],
+  },
+  {
+    id: "cert-004",
+    name: "항공전자 장비 전문판정서",
+    description: "항공전자 제어 시스템",
+    keywords: ["항공", "전자", "제어"],
+  },
+].map((item) => ({
+  ...item,
+  searchValue: [item.name, item.description, ...(item.keywords || [])]
+    .join(" ")
+    .toLowerCase(),
+}));
+
+const ITEM_CURRENCIES = [
+  { value: "", label: "선택" },
+  { value: "KRW", label: "KRW - 대한민국 원" },
+  { value: "USD", label: "USD - 미 달러" },
+  { value: "EUR", label: "EUR - 유로" },
+  { value: "JPY", label: "JPY - 일본 엔" },
+  { value: "CNY", label: "CNY - 중국 위안" },
+  { value: "HKD", label: "HKD - 홍콩 달러" },
+  { value: "TWD", label: "TWD - 대만 달러" },
+];
+
+const ITEM_CURRENCY_OPTIONS_HTML = ITEM_CURRENCIES.map(
+  (currency) => `
+    <option value="${escapeHtml(currency.value)}">${escapeHtml(currency.label)}</option>
+  `
+).join("");
+
+const ITEM_ORIGIN_OPTIONS_HTML = [
+  '<option value="" disabled selected hidden>생산국을 선택하세요</option>',
+  '<option value="기타">기타 (직접 입력)</option>',
+  ...COUNTRY_LIST.map(
+    (country) =>
+      `<option value="${escapeHtml(country.name)}">${escapeHtml(country.name)} (${escapeHtml(country.english)})</option>`
+  ),
+].join("");
+
+const menuContainer = $("[data-menu]");
+const menuButton = menuContainer?.querySelector("[data-menu-button]");
+const menuPanel = menuContainer?.querySelector(".menu-panel");
+
+const infoPageConfigs = {
+  "/expert-certificate": {
+    title: "전략물자 전문판정서",
+    description: "전문판정서 신청 절차와 준비 서류를 빠르게 확인하세요.",
+    body: `
+      <ul class="info-list">
+        <li>필수 서류: 신청서, 품목 규격서, 거래계약서</li>
+        <li>평균 처리 기간: 5~7 영업일</li>
+        <li>진행 상황은 담당자 알림으로 안내됩니다.</li>
+      </ul>
+    `,
+  },
+  "/regulation": {
+    title: "수출관리규정",
+    description: "수출관리규정 전문과 최신 개정 사항을 확인하세요.",
+    body: `
+      <p class="info-note">규정 원문과 개정 이력은 내부 문서함에서 다운로드할 수 있습니다.</p>
+    `,
+  },
+  "/settings": {
+    title: "설정",
+    description: "개인화된 알림과 즐겨찾기 메뉴를 관리하세요.",
+    body: `
+      <ul class="info-list">
+        <li>즐겨찾는 대시보드와 메뉴를 지정합니다.</li>
+        <li>이메일 및 SMS 알림을 켜거나 끕니다.</li>
+        <li>팀 권한과 사용자 정보를 최신 상태로 유지하세요.</li>
+      </ul>
+    `,
+  },
+};
+
+const routes = {
+  "/": () => renderDashboard("/"),
+  "/dashboard": () => renderDashboard("/dashboard"),
+  "/export": renderExport,
+};
+
+Object.entries(infoPageConfigs).forEach(([path, config]) => {
+  routes[path] = () => renderInfoPage(path, config);
+});
+
+const menuRoutes = new Set(["/dashboard", "/export", ...Object.keys(infoPageConfigs)]);
+let menuOpen = false;
+
+function setMenuOpen(open = false) {
+  if (!menuContainer) return;
+  menuOpen = Boolean(open);
+  menuContainer.classList.toggle("open", menuOpen);
+  if (menuButton) {
+    menuButton.setAttribute("aria-expanded", menuOpen ? "true" : "false");
+  }
+  if (menuPanel) {
+    menuPanel.hidden = !menuOpen;
+  }
+}
+
+if (menuButton) {
+  menuButton.addEventListener("click", () => setMenuOpen(!menuOpen));
+}
+
+document.addEventListener("click", (event) => {
+  if (!menuOpen || !menuContainer) return;
+  if (menuContainer.contains(event.target)) return;
+  setMenuOpen(false);
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && menuOpen) {
+    setMenuOpen(false);
+    menuButton?.focus();
+  }
+});
+
+setMenuOpen(false);
+
+function setTopbarActive(pathname) {
+  const normalizedPath = pathname === "/" ? "/dashboard" : pathname;
+  if (menuButton) {
+    if (menuRoutes.has(normalizedPath)) {
+      menuButton.setAttribute("data-active", "true");
+    } else {
+      menuButton.removeAttribute("data-active");
+    }
+  }
+
+  if (menuContainer) {
+    $$(".menu-item", menuContainer).forEach((item) => {
+      const href = item.getAttribute("href");
+      if (href === normalizedPath) {
+        item.setAttribute("aria-current", "page");
+      } else {
+        item.removeAttribute("aria-current");
+      }
+    });
+  }
+}
+
+function renderDashboard(pathname = "/dashboard") {
+  const normalizedPath = pathname === "/" ? "/dashboard" : pathname;
+  setTopbarActive(normalizedPath);
+  document.title = "Dashboard | 수출 및 전략물자";
+  app.innerHTML = `
+    <section class="card hero">
+      <div class="hero-text">
+        <h1>환영합니다 👋</h1>
+        <p>상단의 <strong>수출 및 전략물자</strong> 탭에서 최신 수출현황을 확인해 보세요.</p>
+      </div>
+      <a class="btn primary" href="/export" data-link role="button">수출현황 바로가기</a>
+    </section>
+    <section class="card quick-guide">
+      <h2>빠른 가이드</h2>
+      <ul class="guide-list">
+        <li>검색창에 품목, 국가 또는 상태를 입력해 원하는 데이터를 빠르게 찾을 수 있습니다.</li>
+        <li>새로운 수출 건은 <strong>수출 신규등록</strong> 버튼으로 즉시 추가하세요.</li>
+        <li>등록된 정보는 실시간으로 반영되어 목록에서 바로 확인할 수 있습니다.</li>
+      </ul>
+    </section>
+  `;
+  app.focus();
+}
+
+function renderExport() {
+  setTopbarActive("/export");
+  document.title = "수출현황 | 수출 및 전략물자";
+
+  currentPage = 1;
+  currentQuery = "";
+  lastMeta = { totalPages: 0, totalCount: 0, pageSize: PAGE_SIZE };
+
+  app.innerHTML = `
+    <section class="page-header">
+      <div>
+        <h1>수출현황</h1>
+        <p class="page-description">등록된 수출 건을 검색하고 신규 데이터를 추가하세요.</p>
+      </div>
+      <div class="header-actions">
+        <button id="continueBtn" class="btn" type="button" hidden>이어서 등록하기</button>
+        <button id="newBtn" class="btn primary" type="button">신규등록</button>
+        <button id="reportBtn" class="btn" type="button">수출신고</button>
+        <button id="pickupBtn" class="btn" type="button">픽업요청</button>
+      </div>
+    </section>
+
+    <section class="card search-panel" role="search">
+      <div class="search-input">
+        <input id="q" type="text" placeholder="품목/국가/상태로 검색" aria-label="검색어" />
+      </div>
+      <div class="search-actions">
+        <button id="searchBtn" class="btn" type="button">검색</button>
+      </div>
+    </section>
+
+    <section class="card table-card">
+      <div class="table-wrap">
+        <table class="export-table" aria-label="수출 목록">
+          <colgroup>
+            <col class="col-no" />
+            <col class="col-type" />
+            <col class="col-date" />
+            <col class="col-project" />
+            <col class="col-project-code" />
+            <col class="col-item" />
+            <col class="col-qty" />
+            <col class="col-client" />
+            <col class="col-end-user" />
+            <col class="col-country" />
+            <col class="col-dept" />
+            <col class="col-manager" />
+            <col class="col-select" />
+            <col class="col-pl" />
+            <col class="col-invoice" />
+            <col class="col-permit" />
+            <col class="col-declaration" />
+            <col class="col-usage" />
+            <col class="col-bl" />
+            <col class="col-file" />
+            <col class="col-status" />
+            <col class="col-note" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th scope="col" rowspan="2">NO</th>
+              <th scope="col" rowspan="2">출고유형</th>
+              <th scope="col" rowspan="2">출고일</th>
+              <th scope="col" rowspan="2">프로젝트명</th>
+              <th scope="col" rowspan="2">프로젝트코드</th>
+              <th scope="col" rowspan="2">품목명</th>
+              <th scope="col" rowspan="2">수량</th>
+              <th scope="col" rowspan="2">거래처</th>
+              <th scope="col" rowspan="2">최종사용자</th>
+              <th scope="col" rowspan="2">수출국가</th>
+              <th scope="col" rowspan="2">담당부서</th>
+              <th scope="col" rowspan="2">담당자</th>
+              <th scope="col" rowspan="2">선택</th>
+              <th scope="colgroup" colspan="6">수출증빙</th>
+              <th scope="col" rowspan="2">파일등록 및 수정</th>
+              <th scope="col" rowspan="2">진행상황</th>
+              <th scope="col" rowspan="2">비고</th>
+            </tr>
+            <tr>
+              <th scope="col">PL</th>
+              <th scope="col">INVOICE</th>
+              <th scope="col">전략물자 수출허가서</th>
+              <th scope="col">수출신고서</th>
+              <th scope="col">최종사용자/용도확인</th>
+              <th scope="col">B/L</th>
+            </tr>
+          </thead>
+          <tbody id="tbody"></tbody>
+        </table>
+      </div>
+      <div class="table-footer">
+        <p id="resultCount" class="result-count" role="status" aria-live="polite">총 0건</p>
+        <div class="pagination" id="pagination" role="navigation" aria-label="페이지 이동"></div>
+      </div>
+    </section>
+  `;
+
+  // 이벤트
+  const searchInput = $("#q");
+  $("#searchBtn").addEventListener("click", () => {
+    fetchAndRender({ query: searchInput?.value ?? "" });
+  });
+  searchInput?.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      fetchAndRender({ query: searchInput.value });
+    }
+  });
+  $("#newBtn").addEventListener("click", openNewDialog);
+  const continueButton = $("#continueBtn");
+  if (continueButton) {
+    continueButton.hidden = true;
+    continueButton.addEventListener("click", () => {
+      const selectedIds = getSelectedDraftRowIds();
+      if (!selectedIds.length) return;
+      // 추후 실제 데이터 연동 시 선택한 임시저장 건을 불러오도록 연결
+      openNewDialog();
+    });
+  }
+  $("#pagination").addEventListener("click", onPaginationClick);
+
+  fetchAndRender({ page: 1 });
+  app.focus();
+}
+
+function renderInfoPage(pathname, config) {
+  setTopbarActive(pathname);
+  document.title = `${config.title} | 수출 및 전략물자`;
+  app.innerHTML = `
+    <section class="card info-card">
+      <h1>${config.title}</h1>
+      <p class="page-description">${config.description}</p>
+      ${config.body ?? ""}
+    </section>
+  `;
+  app.focus();
+}
+
+async function fetchAndRender({ page, query } = {}) {
+  if (typeof query === "string") {
+    currentQuery = query.trim();
+    currentPage = 1;
+  }
+
+  const targetPage = page ?? currentPage;
+  const params = new URLSearchParams({
+    query: currentQuery,
+    page: String(Math.max(targetPage, 1)),
+    pageSize: String(PAGE_SIZE),
+  });
+
+  try {
+    const res = await fetch(`/api/exports?${params.toString()}`);
+    if (!res.ok) throw new Error("목록을 불러오지 못했습니다.");
+
+    const data = await res.json();
+    const totalPages = Number(data.totalPages ?? 0);
+    const pageFromServer = totalPages === 0 ? 1 : Number(data.page ?? 1);
+
+    currentPage = pageFromServer;
+    lastServerMeta = {
+      totalPages,
+      totalCount: Number(data.totalCount ?? 0),
+      pageSize: Number(data.pageSize ?? PAGE_SIZE),
+    };
+    lastFetchedItems = data.items ?? [];
+
+    const combinedRows = getCombinedRows(lastFetchedItems);
+    renderRows(combinedRows, { page: currentPage });
+    updateMeta();
+    renderPagination();
+
+    const searchInput = $("#q");
+    if (searchInput && searchInput.value.trim() !== currentQuery) {
+      searchInput.value = currentQuery;
+    }
+  } catch (err) {
+    console.error(err);
+    const tbody = $("#tbody");
+    if (tbody) {
+      tbody.innerHTML = `<tr><td colspan="${EXPORT_TABLE_COLSPAN}" class="error">${escapeHtml(
+        err.message || "목록을 불러오지 못했습니다."
+      )}</td></tr>`;
+    }
+    const pagination = $("#pagination");
+    const resultCount = $("#resultCount");
+    if (pagination) pagination.innerHTML = "";
+    if (resultCount) resultCount.textContent = "총 0건";
+  }
+}
+
+function renderRows(rows = [], meta = {}) {
+  const tbody = $("#tbody");
+  if (!tbody) return;
+
+  const page = meta.page ?? 1;
+  const pageSize = lastMeta.pageSize ?? PAGE_SIZE;
+  const startIndex = (page - 1) * pageSize;
+
+  if (!rows.length) {
+    tbody.innerHTML = `<tr><td colspan="${EXPORT_TABLE_COLSPAN}" data-empty="true">데이터가 없습니다.</td></tr>`;
+    updateContinueButtonVisibility();
+    return;
+  }
+
+  const qtyFormatter = new Intl.NumberFormat("ko-KR");
+
+  const docValue = (value) => {
+    if (value === undefined || value === null || value === "") return "-";
+    return escapeHtml(String(value));
+  };
+
+  tbody.innerHTML = rows
+    .map((row, idx) => {
+      const seq = startIndex + idx + 1;
+      const createdDate = formatDate(row.createdAt);
+      const shipmentType = row.shipmentType ? escapeHtml(String(row.shipmentType)) : "-";
+      const projectName = row.projectName ? escapeHtml(String(row.projectName)) : "-";
+      const projectCode = row.projectCode ? escapeHtml(String(row.projectCode)) : "-";
+      const item = row.item ? escapeHtml(String(row.item)) : "-";
+      const qty = formatNumber(row.qty, qtyFormatter);
+      const client = row.client ? escapeHtml(String(row.client)) : "-";
+      const endUser = row.endUser ? escapeHtml(String(row.endUser)) : "-";
+      const country = row.country ? escapeHtml(String(row.country).toUpperCase()) : "-";
+      const department = row.department ? escapeHtml(String(row.department)) : "-";
+      const manager = row.manager ? escapeHtml(String(row.manager)) : "-";
+      const statusRaw = row.status ? String(row.status) : "";
+      const status = statusRaw ? escapeHtml(statusRaw) : "-";
+      const note = row.note ? escapeHtml(String(row.note)) : "-";
+      const plStatus = docValue(row.plStatus);
+      const invoiceStatus = docValue(row.invoiceStatus);
+      const permitStatus = docValue(row.permitStatus);
+      const declarationStatus = docValue(row.declarationStatus);
+      const usageStatus = docValue(row.usageStatus);
+      const blStatus = docValue(row.blStatus);
+      const fileNote = docValue(row.fileNote);
+      const statusNormalized = statusRaw.replace(/\s+/g, "");
+      const isDraftStatus = Boolean(row.isDraft) || statusNormalized.includes("임시저장");
+      const rowIdentifier = row.id ?? row._id ?? row.seq ?? row.projectCode ?? row.contractNumber ?? row.client ?? `row-${startIndex + idx}`;
+      const selectBox = `<input type="checkbox" data-select data-entry-id="${escapeHtml(String(rowIdentifier))}" data-draft="${isDraftStatus ? "true" : "false"}" aria-label="선택" />`;
+      const rowAttrs = isDraftStatus ? " data-draft=\"true\"" : row.isDraft ? " data-draft=\"true\"" : "";
+
+      return `
+        <tr${rowAttrs}>
+          ${td(String(seq), { align: "center" })}
+          ${td(shipmentType, { empty: shipmentType === "-" })}
+          ${td(createdDate, { empty: createdDate === "-" })}
+          ${td(projectName, { align: "left", empty: projectName === "-" })}
+          ${td(projectCode, { align: "left", empty: projectCode === "-" })}
+          ${td(item, { align: "left", empty: item === "-" })}
+          ${td(qty, { align: "right", empty: qty === "-" })}
+          ${td(client, { align: "left", empty: client === "-" })}
+          ${td(endUser, { align: "left", empty: endUser === "-" })}
+          ${td(country, { align: "center", empty: country === "-" })}
+          ${td(department, { align: "left", empty: department === "-" })}
+          ${td(manager, { align: "left", empty: manager === "-" })}
+          ${td(selectBox, { align: "center" })}
+          ${td(plStatus, { empty: plStatus === "-" })}
+          ${td(invoiceStatus, { empty: invoiceStatus === "-" })}
+          ${td(permitStatus, { empty: permitStatus === "-" })}
+          ${td(declarationStatus, { empty: declarationStatus === "-" })}
+          ${td(usageStatus, { empty: usageStatus === "-" })}
+          ${td(blStatus, { empty: blStatus === "-" })}
+          ${td(fileNote, { align: "left", empty: fileNote === "-" })}
+          ${td(status, { align: "left", empty: status === "-" })}
+          ${td(note, { align: "left", empty: note === "-" })}
+        </tr>
+      `;
+    })
+    .join("");
+
+  ensureSelectionHandlers();
+  updateContinueButtonVisibility();
+}
+
+function ensureSelectionHandlers() {
+  if (selectionHandlersInitialized) return;
+  const tbody = $("#tbody");
+  if (!tbody) return;
+  tbody.addEventListener("change", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    if (target.type !== "checkbox" || !target.hasAttribute("data-select")) return;
+    updateContinueButtonVisibility();
+  });
+  selectionHandlersInitialized = true;
+}
+
+function getSelectedDraftRowIds() {
+  const tbody = $("#tbody");
+  if (!tbody) return [];
+  return $$('input[type="checkbox"][data-select][data-draft="true"]:checked', tbody)
+    .map((input) => input.dataset.entryId)
+    .filter(Boolean);
+}
+
+function updateContinueButtonVisibility() {
+  const continueButton = $("#continueBtn");
+  if (!continueButton) return;
+  const hasDraftSelection = getSelectedDraftRowIds().length > 0;
+  continueButton.hidden = !hasDraftSelection;
+}
+
+function getCombinedRows(serverRows = []) {
+  return serverRows;
+}
+
+function updateMeta() {
+  const serverTotal = lastServerMeta.totalCount ?? 0;
+  const serverPages = lastServerMeta.totalPages ?? 0;
+  const totalPages = serverTotal === 0 ? 0 : serverPages === 0 ? 1 : serverPages;
+  lastMeta = {
+    totalPages,
+    totalCount: serverTotal,
+    pageSize: lastServerMeta.pageSize ?? PAGE_SIZE,
+  };
+}
+
+function collectFormValues(form) {
+  const data = {};
+  const fd = new FormData(form);
+  fd.forEach((value, key) => {
+    const normalized = typeof value === "string" ? value.trim() : value;
+    if (Object.prototype.hasOwnProperty.call(data, key)) {
+      const existing = data[key];
+      if (Array.isArray(existing)) {
+        existing.push(normalized);
+      } else {
+        data[key] = [existing, normalized];
+      }
+    } else {
+      data[key] = normalized;
+    }
+  });
+  return data;
+}
+
+function mapFormDataToPayload(data = {}) {
+  const trim = (val) => (typeof val === "string" ? val.trim() : "");
+  const exportType = trim(data.exportType);
+  const exportTypeDetail = trim(data.exportTypeDetail);
+  const projectName = trim(data.projectName);
+  const projectCode = trim(data.projectCode);
+  const strategicFlag = trim(data.strategicFlag);
+  const strategicExpertCertificate = trim(data.strategicExpertCertificate);
+  const managerName = trim(data.managerName);
+  const managerDepartment = trim(data.managerDepartment);
+  const managerPhone = trim(data.managerPhone);
+  const managerEmail = trim(data.managerEmail);
+  const importCompanyName = trim(data.importCompanyName);
+  const importAddress = trim(data.importAddress);
+  const importCountry = trim(data.importCountry);
+  const importCountryCode = trim(data.importCountryCode);
+  const importPhone = trim(data.importPhone);
+  const importContactName = trim(data.importContactName);
+  const importContactPhone = trim(data.importContactPhone);
+  const importEmail = trim(data.importEmail);
+  const importEtc = trim(data.importEtc);
+  const notifySameAsImporter = Boolean(data.notifySameAsImporter);
+  const notifyCompanyName = trim(data.notifyCompanyName);
+  const notifyAddress = trim(data.notifyAddress);
+  const notifyCountry = trim(data.notifyCountry);
+  const notifyCountryCode = trim(data.notifyCountryCode);
+  const notifyPhone = trim(data.notifyPhone);
+  const notifyContactName = trim(data.notifyContactName);
+  const notifyContactPhone = trim(data.notifyContactPhone);
+  const notifyEmail = trim(data.notifyEmail);
+  const notifyEtc = trim(data.notifyEtc);
+  const originCountry = trim(data.originCountry);
+  const destinationCountry = trim(data.destinationCountry);
+  const dispatchDate = trim(data.dispatchDate);
+  const transportMode = trim(data.transportMode);
+  const transportOther = trim(data.transportOther);
+  const loadingDate = trim(data.loadingDate);
+  const incoterms = trim(data.incoterms);
+  const incotermsOther = trim(data.incotermsOther);
+  const paymentTerms = trim(data.paymentTerms);
+
+  const toArray = (val) => {
+    if (val === undefined || val === null) return [];
+    if (Array.isArray(val)) return val.map((item) => trim(item));
+    return [trim(val)];
+  };
+
+  const itemNos = toArray(data.itemNo);
+  const itemNames = toArray(data.itemName);
+  const itemCategories = toArray(data.itemCategory);
+  const itemQuantities = toArray(data.itemQuantity);
+  const itemCurrencies = toArray(data.itemCurrency);
+  const itemUnitPrices = toArray(data.itemUnitPrice);
+  const itemTotals = toArray(data.itemTotal);
+  const itemOrigins = toArray(data.itemOrigin);
+  const itemOriginOthers = toArray(data.itemOriginOther);
+  const itemCount = Math.max(
+    itemNos.length,
+    itemNames.length,
+    itemCategories.length,
+    itemQuantities.length,
+    itemCurrencies.length,
+    itemUnitPrices.length,
+    itemTotals.length,
+    itemOrigins.length,
+    itemOriginOthers.length,
+  );
+
+  const items = Array.from({ length: itemCount }, (_, idx) => {
+    const originChoice = itemOrigins[idx] ?? "";
+    const originOtherValue = itemOriginOthers[idx] ?? "";
+    const resolvedOrigin = originChoice === "기타" ? originOtherValue : originChoice;
+    return {
+      no: itemNos[idx] ?? "",
+      name: itemNames[idx] ?? "",
+      category: itemCategories[idx] ?? "",
+      quantity: itemQuantities[idx] ?? "",
+      currency: itemCurrencies[idx] ?? "",
+      unitPrice: itemUnitPrices[idx] ?? "",
+      total: itemTotals[idx] ?? "",
+      origin: resolvedOrigin ?? "",
+    };
+  }).filter((item) => Object.values(item).some((value) => value !== "" && value !== undefined));
+
+  const firstItem = items[0] || {};
+  const firstItemQty = Number(firstItem.quantity);
+  const firstItemUnitPrice = Number(firstItem.unitPrice);
+  const normalizedQty = Number.isFinite(firstItemQty) ? firstItemQty : 0;
+  const normalizedUnitPrice = Number.isFinite(firstItemUnitPrice) ? firstItemUnitPrice : 0;
+
+  const resolvedPurpose = exportType === "기타" && exportTypeDetail ? exportTypeDetail : exportType;
+  const resolvedTransportMode = transportMode === "기타" && transportOther ? transportOther : transportMode;
+  const resolvedIncoterms = incoterms === "기타" && incotermsOther ? incotermsOther : incoterms;
+
+  const payload = {
+    exportType,
+    exportTypeDetail: exportType === "기타" ? exportTypeDetail : "",
+    projectName,
+    projectCode,
+    strategicFlag,
+    strategicExpertCertificate,
+    managerName,
+    managerDepartment,
+    managerPhone,
+    managerEmail,
+    importCompanyName,
+    importAddress,
+    importCountry,
+    importCountryCode,
+    importPhone,
+    importContactName,
+    importContactPhone,
+    importEmail,
+    importEtc,
+    notifySameAsImporter,
+    notifyCompanyName,
+    notifyAddress,
+    notifyCountry,
+    notifyCountryCode,
+    notifyPhone,
+    notifyContactName,
+    notifyContactPhone,
+    notifyEmail,
+    notifyEtc,
+    originCountry,
+    destinationCountry,
+    dispatchDate,
+    transportMode,
+    transportOther: transportMode === "기타" ? transportOther : "",
+    loadingDate,
+    incoterms,
+    incotermsOther: incoterms === "기타" ? incotermsOther : "",
+    paymentTerms,
+    items,
+    item: firstItem.name || "",
+    qty: normalizedQty,
+    unitPrice: normalizedUnitPrice,
+    currency: firstItem.currency || "",
+    requester: {
+      name: managerName,
+      department: managerDepartment,
+      phone: managerPhone,
+      email: managerEmail,
+    },
+    importer: {
+      companyName: importCompanyName,
+      address: importAddress,
+      country: importCountry,
+      countryCode: importCountryCode,
+      phone: importPhone,
+      contactName: importContactName,
+      contactPhone: importContactPhone,
+      email: importEmail,
+      etc: importEtc,
+    },
+    notifyParty: {
+      sameAsImporter: notifySameAsImporter,
+      companyName: notifyCompanyName,
+      address: notifyAddress,
+      country: notifyCountry,
+      countryCode: notifyCountryCode,
+      phone: notifyPhone,
+      contactName: notifyContactName,
+      contactPhone: notifyContactPhone,
+      email: notifyEmail,
+      etc: notifyEtc,
+    },
+    shipment: {
+      originCountry,
+      destinationCountry,
+      dispatchDate,
+      loadingDate,
+      transportMode: resolvedTransportMode,
+      transportModeRaw: transportMode,
+      incoterms: resolvedIncoterms,
+      incotermsRaw: incoterms,
+      paymentTerms,
+    },
+    shipmentType: exportType,
+    shipmentPurpose: resolvedPurpose,
+    projectNameDisplay: projectName,
+    projectCodeDisplay: projectCode,
+    department: managerDepartment,
+    manager: managerName,
+    managerEmail,
+    contactPhone: managerPhone,
+    client: importCompanyName,
+    clientCountry: importCountry,
+    clientManager: importContactName,
+    note: importEtc,
+    country: (importCountry || destinationCountry || firstItem.origin || originCountry || "").toUpperCase(),
+    status: "대기",
+  };
+  return payload;
+}
+
+function mapFormDataToRow(data = {}, { draft = false } = {}) {
+  const payload = mapFormDataToPayload(data);
+  const row = {
+    ...payload,
+    createdAt: Date.now(),
+    status: draft ? "임시저장" : payload.status,
+    note: payload.note || (draft ? "임시 저장" : ""),
+    isDraft: draft,
+  };
+  row.country = payload.country ? payload.country.toUpperCase() : "";
+  return row;
+}
+
+function addDraftEntry(data) {
+  const row = mapFormDataToRow(data, { draft: true });
+  row.id = `D${Date.now()}_${Math.abs(draftSeq--)}`;
+  draftEntries.unshift(row);
+}
+
+function formHasInput(form) {
+  const elements = Array.from(form.elements || []);
+  return elements.some((el) => {
+    if (!el || !el.name) return false;
+    if (el.type === "button" || el.type === "submit" || el.type === "reset" || el.type === "hidden") return false;
+    if (el instanceof HTMLInputElement) {
+      if (el.type === "checkbox" || el.type === "radio") {
+        return el.checked;
+      }
+      return el.value.trim() !== "";
+    }
+    if (el instanceof HTMLSelectElement || el instanceof HTMLTextAreaElement) {
+      return (el.value || "").trim() !== "";
+    }
+    return false;
+  });
+}
+
+function renderPagination() {
+  const pagination = $("#pagination");
+  const resultCount = $("#resultCount");
+  if (!pagination || !resultCount) return;
+
+  const totalCount = lastMeta.totalCount ?? 0;
+  const totalPages = lastMeta.totalPages ?? 0;
+  resultCount.textContent = `총 ${totalCount.toLocaleString("ko-KR")}건`;
+
+  if (totalPages === 0) {
+    pagination.innerHTML = `
+      <div class="page-info" data-empty="true">0 / 0</div>
+    `;
+    return;
+  }
+
+  const disabledPrev = currentPage <= 1;
+  const disabledNext = currentPage >= totalPages;
+
+  pagination.innerHTML = `
+    <button type="button" class="btn page-btn" data-page-action="first" ${
+      disabledPrev ? "disabled" : ""
+    } aria-label="첫 페이지">≪</button>
+    <button type="button" class="btn page-btn" data-page-action="prev" ${
+      disabledPrev ? "disabled" : ""
+    } aria-label="이전 페이지">＜</button>
+    <div class="page-info"><strong>${currentPage}</strong> / ${totalPages}</div>
+    <button type="button" class="btn page-btn" data-page-action="next" ${
+      disabledNext ? "disabled" : ""
+    } aria-label="다음 페이지">＞</button>
+    <button type="button" class="btn page-btn" data-page-action="last" ${
+      disabledNext ? "disabled" : ""
+    } aria-label="마지막 페이지">≫</button>
+  `;
+}
+
+function onPaginationClick(event) {
+  const button = event.target.closest("[data-page-action]");
+  if (!button || button.disabled) return;
+
+  const action = button.dataset.pageAction;
+  const totalPages = lastMeta.totalPages ?? 0;
+
+  let nextPage = currentPage;
+  if (action === "first") {
+    nextPage = 1;
+  } else if (action === "prev") {
+    nextPage = Math.max(1, currentPage - 1);
+  } else if (action === "next") {
+    nextPage = totalPages === 0 ? currentPage + 1 : Math.min(totalPages, currentPage + 1);
+  } else if (action === "last") {
+    nextPage = totalPages === 0 ? currentPage : totalPages;
+  }
+
+  if (nextPage < 1) nextPage = 1;
+  if (totalPages > 0 && nextPage > totalPages) nextPage = totalPages;
+  if (nextPage !== currentPage) {
+    fetchAndRender({ page: nextPage });
+  }
+}
+
+function formatDate(value) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function formatNumber(value, formatter) {
+  if (value === undefined || value === null || value === "") return "-";
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "-";
+  return (formatter ?? new Intl.NumberFormat("ko-KR")).format(num);
+}
+
+function td(content, { align, empty = false } = {}) {
+  const classes = [];
+  if (align) classes.push(`text-${align}`);
+  const classAttr = classes.length ? ` class="${classes.join(" ")}"` : "";
+  const emptyAttr = empty ? ' data-empty="true"' : "";
+  return `<td${classAttr}${emptyAttr}>${content}</td>`;
+}
+
+function openNewDialog() {
+  const dialog = $("#newExportDialog");
+  const form = $("#newExportForm");
+  if (!dialog || !form) return;
+
+  form.reset();
+
+  const steps = $$(".step", form);
+  const totalSteps = steps.length;
+  let currentStep = 0;
+  const packingStepIndex = steps.findIndex((step) => step.hasAttribute("data-packing-step"));
+  let syncPackingVisibility = null;
+
+  const stepIndicator = $("#newExportStep");
+  const stepTitle = $("#newExportSection");
+  const prevButton = form.querySelector("[data-step-prev]");
+  const nextButton = form.querySelector("[data-step-next]");
+  const saveButton = form.querySelector("[data-step-save]");
+  const completeButton = form.querySelector("[data-step-complete]");
+  const cancelButton = form.querySelector("[data-dialog-cancel]");
+
+  const exportTypeSelect = form.querySelector("select[name=exportType]");
+  const exportTypeDetailLabel = form.querySelector("[data-export-type-detail]");
+  const exportTypeDetailInput = form.querySelector("input[name=exportTypeDetail]");
+  const strategicGroup = form.querySelector("[data-required-group]");
+  const strategicValueInput = form.querySelector("[data-strategic-value]");
+  const strategicOptions = strategicGroup
+    ? $$('input[type="checkbox"][data-strategic-option]', strategicGroup)
+    : [];
+  const expertSearchContainer = form.querySelector('[data-expert-search]');
+  const expertKeywordInput = expertSearchContainer?.querySelector('[data-expert-input]');
+  const expertSearchButton = expertSearchContainer?.querySelector('[data-expert-search-btn]');
+  const expertResultsList = expertSearchContainer?.querySelector('[data-expert-results]');
+  const expertSelectedName = expertSearchContainer?.querySelector('[data-expert-selected-name]');
+  const expertSelectedValueInput = expertSearchContainer?.querySelector('[data-expert-selected-value]');
+  const expertClearButton = expertSearchContainer?.querySelector('[data-expert-clear]');
+  const countrySelectContainer = form.querySelector("[data-country-select]");
+  const simpleCountrySelects = $$('[data-country-select-simple]', form);
+  const notifyCheckbox = form.querySelector('[data-notify-copy]');
+  const transportModeSelect = form.querySelector('select[name=transportMode]');
+  const transportDetailLabel = form.querySelector('[data-transport-detail]');
+  const transportOtherInput = form.querySelector('input[name=transportOther]');
+  const incotermsSelect = form.querySelector('select[name=incoterms]');
+  const incotermsDetailLabel = form.querySelector('[data-incoterms-detail]');
+  const incotermsOtherInput = form.querySelector('input[name=incotermsOther]');
+  const itemsStep = form.querySelector('[data-items-step]');
+  const itemRows = itemsStep?.querySelector('[data-item-rows]');
+  const addItemButton = itemsStep?.querySelector('[data-item-add]');
+  const removeItemButton = itemsStep?.querySelector('[data-item-remove]');
+
+  const isStepComplete = (index) => {
+    const stepEl = steps[index];
+    if (!stepEl) return true;
+
+    const requiredInputs = $$('[required]', stepEl);
+    for (const input of requiredInputs) {
+      if (input.disabled) continue;
+      if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement || input instanceof HTMLSelectElement) {
+        if (input.type === "checkbox" || input.type === "radio") {
+          if (!input.checked) return false;
+        } else if (!input.checkValidity() || (input.value ?? "").trim() === "") {
+          return false;
+        }
+      }
+    }
+
+    const requiredGroups = $$('[data-required-group]', stepEl);
+    for (const group of requiredGroups) {
+      const options = $$('input[type="checkbox"]', group).filter((opt) => !opt.disabled);
+      if (!options.some((opt) => opt.checked)) {
+        return false;
+      }
+    }
+
+    const hiddenRequired = $$('[data-required-hidden]', stepEl);
+    for (const hidden of hiddenRequired) {
+      if (hidden instanceof HTMLInputElement || hidden instanceof HTMLTextAreaElement) {
+        if ((hidden.value ?? "").trim() === "") {
+          return false;
+        }
+      }
+    }
+
+    if (expertSearchContainer && stepEl.contains(expertSearchContainer)) {
+      const requiresExpert = (strategicValueInput?.value || "") === "전략물자 수출";
+      const selectedValue =
+        expertSelectedValueInput instanceof HTMLInputElement
+          ? (expertSelectedValueInput.value || "").trim()
+          : "";
+      if (requiresExpert && !selectedValue) {
+        return false;
+      }
+    }
+
+    if (stepEl.hasAttribute("data-items-step")) {
+      const rows = $$('[data-item-row]', stepEl);
+      if (!rows.length) return false;
+      for (const row of rows) {
+        const inputs = $$('[data-item-input]', row);
+        for (const input of inputs) {
+          if (input.disabled) continue;
+          if (typeof input.value === "string" && input.value.trim() === "") {
+            return false;
+          }
+        }
+      }
+    }
+
+    if (stepEl.hasAttribute("data-packing-step")) {
+      const packingState = form._packingState;
+      if (!packingState || !Array.isArray(packingState.packings) || !packingState.packings.length) {
+        return false;
+      }
+      const hasValidItems = packingState.packings.every(
+        (packing) => Array.isArray(packing.itemKeys) && packing.itemKeys.length > 0
+      );
+      if (!hasValidItems) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  const updateStepActionState = () => {
+    const complete = isStepComplete(currentStep);
+    if (prevButton) {
+      prevButton.disabled = currentStep === 0;
+    }
+    if (nextButton) {
+      nextButton.disabled = currentStep >= totalSteps - 1 || !complete;
+    }
+    if (completeButton) {
+      completeButton.disabled = currentStep !== totalSteps - 1 || !complete;
+    }
+  };
+
+  const toggleExportTypeDetail = () => {
+    const needDetail = exportTypeSelect?.value === "기타";
+    if (exportTypeDetailLabel) {
+      if (needDetail) {
+        exportTypeDetailLabel.removeAttribute("hidden");
+      } else {
+        exportTypeDetailLabel.setAttribute("hidden", "true");
+      }
+    }
+    if (exportTypeDetailInput) {
+      exportTypeDetailInput.disabled = !needDetail;
+      exportTypeDetailInput.required = Boolean(needDetail);
+      if (!needDetail) {
+        exportTypeDetailInput.value = "";
+      }
+    }
+    updateStepActionState();
+  };
+
+  const setupExpertSearch = () => {
+    if (!expertSearchContainer) return;
+
+    const state =
+      expertSearchContainer._expertState || {
+        enabled: false,
+        results: [],
+        selected: null,
+      };
+    expertSearchContainer._expertState = state;
+
+    const updateSelectionDisplay = () => {
+      const hasSelection = Boolean(state.selected);
+      if (expertSelectedName instanceof HTMLElement) {
+        expertSelectedName.textContent = hasSelection ? state.selected.name : "없음";
+      }
+      if (expertSelectedValueInput instanceof HTMLInputElement) {
+        expertSelectedValueInput.value = hasSelection ? state.selected.name : "";
+      }
+      if (expertClearButton instanceof HTMLButtonElement) {
+        expertClearButton.hidden = !hasSelection;
+      }
+      expertSearchContainer.dataset.selected = hasSelection ? "true" : "false";
+    };
+
+    const clearSelection = ({ silent } = {}) => {
+      state.selected = null;
+      updateSelectionDisplay();
+      if (!silent) {
+        updateStepActionState();
+      }
+    };
+
+    const selectCertificate = (certificate, { silent } = {}) => {
+      if (!certificate) return;
+      state.selected = certificate;
+      updateSelectionDisplay();
+      if (expertResultsList instanceof HTMLElement) {
+        expertResultsList.hidden = true;
+      }
+      if (!silent) {
+        updateStepActionState();
+      }
+    };
+
+    const updateSearchButtonState = () => {
+      if (!(expertSearchButton instanceof HTMLButtonElement)) return;
+      const keyword = (expertKeywordInput instanceof HTMLInputElement ? expertKeywordInput.value : "").trim();
+      expertSearchButton.disabled = !state.enabled || keyword.length === 0;
+    };
+
+    const showMessage = (message) => {
+      if (!(expertResultsList instanceof HTMLElement)) return;
+      if (!state.enabled) {
+        expertResultsList.innerHTML = "";
+        expertResultsList.hidden = true;
+        return;
+      }
+      expertResultsList.innerHTML = `
+        <li class="expert-search-empty" role="option" aria-disabled="true">${escapeHtml(message)}</li>
+      `;
+      expertResultsList.hidden = false;
+      state.results = [];
+    };
+
+    const renderResults = (items) => {
+      if (!(expertResultsList instanceof HTMLElement)) return;
+      if (!state.enabled) {
+        expertResultsList.innerHTML = "";
+        expertResultsList.hidden = true;
+        return;
+      }
+      state.results = items;
+      if (!items.length) {
+        showMessage("검색 결과가 없습니다.");
+        return;
+      }
+      expertResultsList.innerHTML = items
+        .map(
+          (item) => `
+            <li>
+              <button type="button" class="expert-search-option" role="option" data-expert-option data-expert-id="${escapeHtml(
+                item.id
+              )}">
+                <span class="expert-search-option-name">${escapeHtml(item.name)}</span>
+                <span class="expert-search-option-desc">${escapeHtml(item.description)}</span>
+              </button>
+            </li>
+          `
+        )
+        .join("");
+      expertResultsList.hidden = false;
+    };
+
+    const handleSearch = () => {
+      if (!state.enabled) return;
+      const keyword = (expertKeywordInput instanceof HTMLInputElement ? expertKeywordInput.value : "").trim().toLowerCase();
+      if (!keyword) {
+        showMessage("검색어를 입력해주세요.");
+        return;
+      }
+      const results = EXPERT_CERTIFICATES.filter((item) => item.searchValue.includes(keyword));
+      if (!results.length) {
+        showMessage("검색 결과가 없습니다.");
+        return;
+      }
+      renderResults(results);
+    };
+
+    const setEnabled = (enabled) => {
+      const nextEnabled = Boolean(enabled);
+      expertSearchContainer.dataset.enabled = nextEnabled ? "true" : "false";
+      if (state.enabled === nextEnabled) {
+        updateSearchButtonState();
+        if (!nextEnabled && expertResultsList instanceof HTMLElement) {
+          expertResultsList.hidden = true;
+        }
+        return;
+      }
+      state.enabled = nextEnabled;
+      if (expertKeywordInput instanceof HTMLInputElement) {
+        expertKeywordInput.disabled = !state.enabled;
+        if (!state.enabled) {
+          expertKeywordInput.value = "";
+        }
+      }
+      if (expertSearchButton instanceof HTMLButtonElement) {
+        expertSearchButton.disabled = !state.enabled;
+      }
+      if (!state.enabled) {
+        if (expertResultsList instanceof HTMLElement) {
+          expertResultsList.innerHTML = "";
+          expertResultsList.hidden = true;
+        }
+        clearSelection({ silent: true });
+      }
+      updateSearchButtonState();
+      updateStepActionState();
+    };
+
+    state.clearSelection = clearSelection;
+    state.setEnabled = setEnabled;
+    state.selectCertificate = selectCertificate;
+    state.updateSearchButtonState = updateSearchButtonState;
+
+    if (!expertSearchContainer.dataset.boundExpert) {
+      if (expertKeywordInput instanceof HTMLInputElement) {
+        expertKeywordInput.addEventListener("input", () => {
+          updateSearchButtonState();
+        });
+        expertKeywordInput.addEventListener("keydown", (event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            handleSearch();
+          }
+        });
+      }
+      if (expertSearchButton instanceof HTMLButtonElement) {
+        expertSearchButton.addEventListener("click", handleSearch);
+      }
+      if (expertResultsList instanceof HTMLElement) {
+        expertResultsList.addEventListener("click", (event) => {
+          const option = event.target.closest("[data-expert-option]");
+          if (!(option instanceof HTMLButtonElement)) return;
+          const id = option.dataset.expertId;
+          const certificate = id ? EXPERT_CERTIFICATES.find((item) => item.id === id) : null;
+          if (certificate) {
+            selectCertificate(certificate);
+          }
+        });
+      }
+      if (expertClearButton instanceof HTMLButtonElement) {
+        expertClearButton.addEventListener("click", () => {
+          clearSelection();
+          if (expertKeywordInput instanceof HTMLInputElement) {
+            expertKeywordInput.focus();
+          }
+        });
+      }
+      expertSearchContainer.dataset.boundExpert = "true";
+    }
+
+    setEnabled(false);
+    clearSelection({ silent: true });
+    updateSearchButtonState();
+  };
+
+  const syncStrategicDependencies = ({ silent } = {}) => {
+    const value = strategicValueInput?.value?.trim() || "";
+    const expertState = expertSearchContainer?._expertState;
+    const isStrategic = value === "전략물자 수출";
+    if (expertState?.setEnabled) {
+      expertState.setEnabled(isStrategic);
+    } else if (!silent) {
+      updateStepActionState();
+    }
+  };
+
+  const handleStrategicOptionChange = (input) => {
+    if (!(input instanceof HTMLInputElement)) return;
+    if (input.checked) {
+      strategicOptions.forEach((opt) => {
+        if (opt !== input) opt.checked = false;
+      });
+      if (strategicValueInput) {
+        strategicValueInput.value = input.value;
+      }
+    } else {
+      const selected = strategicOptions.find((opt) => opt.checked);
+      if (strategicValueInput) {
+        strategicValueInput.value = selected ? selected.value : "";
+      }
+    }
+    syncStrategicDependencies({ silent: true });
+    updateStepActionState();
+  };
+
+  const setupStrategicGroup = () => {
+    if (!strategicGroup) return;
+    if (strategicValueInput) strategicValueInput.value = "";
+    strategicOptions.forEach((option) => {
+      option.checked = false;
+      if (!option.dataset.boundStrategic) {
+        option.addEventListener("change", (event) => {
+          if (event.target instanceof HTMLInputElement) {
+            handleStrategicOptionChange(event.target);
+          }
+        });
+        option.dataset.boundStrategic = "true";
+      }
+    });
+    if (!form.dataset.boundStrategicReset) {
+      form.addEventListener("reset", () => {
+        window.requestAnimationFrame(() => {
+          if (strategicValueInput) {
+            strategicValueInput.value = "";
+          }
+          syncStrategicDependencies({ silent: true });
+        });
+      });
+      form.dataset.boundStrategicReset = "true";
+    }
+    syncStrategicDependencies({ silent: true });
+  };
+
+  const setupCountrySelector = () => {
+    if (!countrySelectContainer) return;
+    const toggle = countrySelectContainer.querySelector("[data-country-toggle]");
+    const menu = countrySelectContainer.querySelector("[data-country-menu]");
+    const optionsList = countrySelectContainer.querySelector("[data-country-options]");
+    const searchInput = countrySelectContainer.querySelector("[data-country-search]");
+    const hiddenInput = countrySelectContainer.querySelector("[data-country-value]");
+    const flagEl = countrySelectContainer.querySelector("[data-country-flag]");
+    const labelEl = countrySelectContainer.querySelector("[data-country-label]");
+    const dialEl = countrySelectContainer.querySelector("[data-country-selected-dial]");
+    const codeInput = form.querySelector("[data-country-code]");
+
+    if (!(toggle instanceof HTMLButtonElement) || !menu || !optionsList || !(hiddenInput instanceof HTMLInputElement)) {
+      return;
+    }
+
+    const container = countrySelectContainer;
+    const DEFAULT_LABEL = "국가를 선택하세요";
+    const DEFAULT_FLAG = "🌐";
+
+    const renderOptions = (items) => {
+      if (!(optionsList instanceof HTMLElement)) return;
+      if (!Array.isArray(items) || items.length === 0) {
+        optionsList.innerHTML = '<li class="country-empty">검색 결과가 없습니다.</li>';
+        return;
+      }
+      optionsList.innerHTML = items
+        .map((country) => {
+          const selected = hiddenInput.value === country.name;
+          const selectedAttr = selected ? ' data-selected="true" aria-selected="true"' : ' aria-selected="false"';
+          return `
+            <li>
+              <button type="button" class="country-option" role="option"${selectedAttr} data-country-option data-country-name="${escapeHtml(
+                country.name
+              )}" data-country-dial="${escapeHtml(country.dialCode)}" data-country-iso="${escapeHtml(country.iso2)}">
+                <span class="country-flag">${escapeHtml(country.flag)}</span>
+                <span class="country-info">
+                  <span class="country-name">${escapeHtml(country.name)}</span>
+                  <span class="country-en">${escapeHtml(country.english)}</span>
+                </span>
+                <span class="country-dial">${escapeHtml(country.dialCode)}</span>
+              </button>
+            </li>
+          `;
+        })
+        .join("");
+    };
+
+    const filterOptions = (keyword = "") => {
+      const value = keyword.trim().toLowerCase();
+      const filtered = value
+        ? COUNTRY_LIST.filter((country) => country.searchValue.includes(value))
+        : COUNTRY_LIST.slice();
+      renderOptions(filtered);
+    };
+
+    const closeMenu = () => {
+      if (menu.hasAttribute("hidden")) return;
+      menu.setAttribute("hidden", "true");
+      container.classList.remove("open");
+      toggle.setAttribute("aria-expanded", "false");
+      if (searchInput instanceof HTMLInputElement) {
+        searchInput.value = "";
+      }
+      filterOptions("");
+    };
+
+    const openMenu = () => {
+      if (!menu.hasAttribute("hidden")) return;
+      menu.removeAttribute("hidden");
+      container.classList.add("open");
+      toggle.setAttribute("aria-expanded", "true");
+      if (searchInput instanceof HTMLInputElement) {
+        searchInput.value = "";
+      }
+      filterOptions("");
+      window.requestAnimationFrame(() => {
+        if (searchInput instanceof HTMLInputElement) {
+          searchInput.focus();
+        }
+      });
+    };
+
+    const resetSelection = ({ silent } = {}) => {
+      if (flagEl) flagEl.textContent = DEFAULT_FLAG;
+      if (labelEl) labelEl.textContent = DEFAULT_LABEL;
+      if (dialEl) dialEl.textContent = "";
+      toggle.setAttribute("data-placeholder", "true");
+      hiddenInput.value = "";
+      if (codeInput instanceof HTMLInputElement) {
+        codeInput.value = "";
+      }
+      if (!silent) {
+        updateStepActionState();
+      }
+    };
+
+    const selectCountry = (country, { silent } = {}) => {
+      if (!country) return;
+      if (flagEl) flagEl.textContent = country.flag;
+      if (labelEl) labelEl.textContent = country.name;
+      if (dialEl) dialEl.textContent = `${country.dialCode} · ${country.english}`;
+      toggle.setAttribute("data-placeholder", "false");
+      hiddenInput.value = country.name;
+      hiddenInput.dispatchEvent(new Event("input", { bubbles: true }));
+      hiddenInput.dispatchEvent(new Event("change", { bubbles: true }));
+      if (codeInput instanceof HTMLInputElement) {
+        codeInput.value = country.dialCode;
+      }
+      if (!silent) {
+        updateStepActionState();
+      }
+    };
+
+    resetSelection({ silent: true });
+    filterOptions("");
+
+    if (!container.dataset.boundCountry) {
+      const handleDocumentClick = (event) => {
+        if (!container.classList.contains("open")) return;
+        if (container.contains(event.target)) return;
+        closeMenu();
+      };
+
+      toggle.addEventListener("click", (event) => {
+        event.preventDefault();
+        if (container.classList.contains("open")) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      toggle.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          openMenu();
+        } else if (event.key === "Escape") {
+          closeMenu();
+        }
+      });
+
+      if (searchInput instanceof HTMLInputElement) {
+        searchInput.addEventListener("input", (event) => {
+          filterOptions(event.target.value || "");
+        });
+        searchInput.addEventListener("keydown", (event) => {
+          if (event.key === "ArrowDown") {
+            event.preventDefault();
+            const firstOption = optionsList.querySelector("[data-country-option]");
+            if (firstOption instanceof HTMLElement) {
+              firstOption.focus();
+            }
+          } else if (event.key === "Escape") {
+            event.preventDefault();
+            closeMenu();
+            toggle.focus();
+          } else if (event.key === "Enter") {
+            event.preventDefault();
+          }
+        });
+      }
+
+      const focusOption = (base, direction) => {
+        const buttons = [...optionsList.querySelectorAll("[data-country-option]")];
+        if (!buttons.length) return;
+        if (direction === "first") {
+          buttons[0].focus();
+          return;
+        }
+        if (direction === "last") {
+          buttons[buttons.length - 1].focus();
+          return;
+        }
+        const currentIndex = base ? buttons.indexOf(base) : -1;
+        const nextIndex = currentIndex < 0 ? (direction > 0 ? 0 : buttons.length - 1) : Math.max(0, Math.min(buttons.length - 1, currentIndex + direction));
+        buttons[nextIndex].focus();
+      };
+
+      optionsList.addEventListener("click", (event) => {
+        const button = event.target.closest("[data-country-option]");
+        if (!button) return;
+        const iso = button.dataset.countryIso;
+        const name = button.dataset.countryName;
+        const dial = button.dataset.countryDial;
+        const country = COUNTRY_LIST.find((item) => item.iso2 === iso && item.dialCode === dial && item.name === name) ||
+          COUNTRY_LIST.find((item) => item.iso2 === iso) ||
+          COUNTRY_LIST.find((item) => item.name === name);
+        if (country) {
+          selectCountry(country);
+          closeMenu();
+          toggle.focus();
+        }
+      });
+
+      optionsList.addEventListener("keydown", (event) => {
+        const option = event.target.closest("[data-country-option]");
+        if (!option) return;
+        if (event.key === "ArrowDown") {
+          event.preventDefault();
+          focusOption(option, 1);
+        } else if (event.key === "ArrowUp") {
+          event.preventDefault();
+          focusOption(option, -1);
+        } else if (event.key === "Home") {
+          event.preventDefault();
+          focusOption(option, "first");
+        } else if (event.key === "End") {
+          event.preventDefault();
+          focusOption(option, "last");
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          closeMenu();
+          toggle.focus();
+        } else if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          option.click();
+        }
+      });
+
+      document.addEventListener("click", handleDocumentClick);
+
+      form.addEventListener("reset", () => {
+        window.requestAnimationFrame(() => {
+          resetSelection({ silent: true });
+          closeMenu();
+          updateStepActionState();
+        });
+      });
+
+      container.dataset.boundCountry = "true";
+    } else {
+      resetSelection({ silent: true });
+      closeMenu();
+      filterOptions("");
+    }
+  };
+
+  const findCountryByName = (name) => {
+    if (!name) return undefined;
+    return COUNTRY_LIST.find((country) => country.name === name);
+  };
+
+  const ensureSimpleCountryOptions = (select) => {
+    if (!(select instanceof HTMLSelectElement)) return;
+    if (select.dataset.simpleOptionsLoaded === "true") return;
+    const options = COUNTRY_LIST.map((country) => `<option value="${escapeHtml(country.name)}">${escapeHtml(country.name)}</option>`).join("");
+    const placeholderOption = select.querySelector('option[value=""]');
+    const placeholderHtml = placeholderOption ? placeholderOption.outerHTML : '<option value="">선택</option>';
+    select.innerHTML = `${placeholderHtml}${options}`;
+    select.dataset.simpleOptionsLoaded = "true";
+  };
+
+  const updateSimpleSelectDial = (select) => {
+    if (!(select instanceof HTMLSelectElement)) return;
+    const targetName = select.dataset.codeTarget;
+    if (!targetName) return;
+    const target = form.querySelector(`[name="${targetName}"]`);
+    if (!(target instanceof HTMLInputElement)) return;
+    const selectedCountry = findCountryByName(select.value);
+    target.value = selectedCountry ? selectedCountry.dialCode : "";
+  };
+
+  const setupSimpleCountrySelects = () => {
+    if (!simpleCountrySelects.length) return;
+    simpleCountrySelects.forEach((select) => {
+      if (!(select instanceof HTMLSelectElement)) return;
+      ensureSimpleCountryOptions(select);
+      updateSimpleSelectDial(select);
+      if (!select.dataset.boundSimpleCountry) {
+        select.addEventListener("change", () => {
+          updateSimpleSelectDial(select);
+          updateStepActionState();
+        });
+        form.addEventListener("reset", () => {
+          window.requestAnimationFrame(() => {
+            updateSimpleSelectDial(select);
+            updateStepActionState();
+          });
+        });
+        select.dataset.boundSimpleCountry = "true";
+      }
+    });
+  };
+
+  const setupNotifyCopy = () => {
+    if (!notifyCheckbox) return;
+
+    const importerFields = {
+      company: form.querySelector('input[name="importCompanyName"]'),
+      address: form.querySelector('input[name="importAddress"]'),
+      country: form.querySelector('input[name="importCountry"]'),
+      countryCode: form.querySelector('input[name="importCountryCode"]'),
+      phone: form.querySelector('input[name="importPhone"]'),
+      contactName: form.querySelector('input[name="importContactName"]'),
+      contactPhone: form.querySelector('input[name="importContactPhone"]'),
+      email: form.querySelector('input[name="importEmail"]'),
+      etc: form.querySelector('textarea[name="importEtc"]'),
+    };
+
+    const notifyFields = {
+      company: form.querySelector('input[name="notifyCompanyName"]'),
+      address: form.querySelector('input[name="notifyAddress"]'),
+      country: form.querySelector('select[name="notifyCountry"]'),
+      countryCode: form.querySelector('input[name="notifyCountryCode"]'),
+      phone: form.querySelector('input[name="notifyPhone"]'),
+      contactName: form.querySelector('input[name="notifyContactName"]'),
+      contactPhone: form.querySelector('input[name="notifyContactPhone"]'),
+      email: form.querySelector('input[name="notifyEmail"]'),
+      etc: form.querySelector('textarea[name="notifyEtc"]'),
+    };
+
+    const state = form._notifyCopyState || { suppress: false };
+    form._notifyCopyState = state;
+
+    const copyFields = () => {
+      state.suppress = true;
+      if (notifyFields.company && importerFields.company) notifyFields.company.value = importerFields.company.value;
+      if (notifyFields.address && importerFields.address) notifyFields.address.value = importerFields.address.value;
+      if (notifyFields.phone && importerFields.phone) notifyFields.phone.value = importerFields.phone.value;
+      if (notifyFields.contactName && importerFields.contactName) notifyFields.contactName.value = importerFields.contactName.value;
+      if (notifyFields.contactPhone && importerFields.contactPhone) notifyFields.contactPhone.value = importerFields.contactPhone.value;
+      if (notifyFields.email && importerFields.email) notifyFields.email.value = importerFields.email.value;
+      if (notifyFields.etc && importerFields.etc) notifyFields.etc.value = importerFields.etc.value;
+
+      const importCountryValue = importerFields.country?.value ?? "";
+      if (notifyFields.country instanceof HTMLSelectElement) {
+        ensureSimpleCountryOptions(notifyFields.country);
+        const hasOption = Array.from(notifyFields.country.options).some((option) => option.value === importCountryValue);
+        notifyFields.country.value = hasOption ? importCountryValue : "";
+        notifyFields.country.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+      if (notifyFields.countryCode && importerFields.countryCode) {
+        notifyFields.countryCode.value = importerFields.countryCode.value;
+      }
+
+      state.suppress = false;
+      updateStepActionState();
+    };
+
+    state.copyFields = copyFields;
+
+    const handleImporterChange = () => {
+      if (!notifyCheckbox.checked) return;
+      copyFields();
+    };
+
+    const handleNotifyInput = () => {
+      if (state.suppress) return;
+      if (!notifyCheckbox.checked) return;
+      notifyCheckbox.checked = false;
+      updateStepActionState();
+    };
+
+    if (!state.bound) {
+      notifyCheckbox.addEventListener("change", () => {
+        if (notifyCheckbox.checked) {
+          copyFields();
+        }
+        updateStepActionState();
+      });
+
+      Object.values(importerFields).forEach((field) => {
+        if (!field) return;
+        field.addEventListener("input", handleImporterChange);
+        field.addEventListener("change", handleImporterChange);
+      });
+
+      Object.values(notifyFields).forEach((field) => {
+        if (!field) return;
+        if (field === notifyFields.countryCode) return;
+        field.addEventListener("input", handleNotifyInput);
+        field.addEventListener("change", handleNotifyInput);
+      });
+
+      state.bound = true;
+    }
+
+    if (notifyCheckbox.checked) {
+      copyFields();
+    }
+  };
+
+  const setupTransportModeField = () => {
+    if (!transportModeSelect || !transportOtherInput) return;
+    const toggleDetail = () => {
+      const needDetail = transportModeSelect.value === "기타";
+      if (transportDetailLabel) {
+        if (needDetail) {
+          transportDetailLabel.removeAttribute("hidden");
+        } else {
+          transportDetailLabel.setAttribute("hidden", "true");
+        }
+      }
+      transportOtherInput.disabled = !needDetail;
+      transportOtherInput.required = needDetail;
+      if (!needDetail) {
+        transportOtherInput.value = "";
+      }
+      updateStepActionState();
+    };
+
+    if (!transportModeSelect.dataset.boundTransport) {
+      transportModeSelect.addEventListener("change", toggleDetail);
+      form.addEventListener("reset", () => {
+        window.requestAnimationFrame(() => {
+          toggleDetail();
+        });
+      });
+      transportModeSelect.dataset.boundTransport = "true";
+    }
+
+    toggleDetail();
+  };
+
+  const setupIncotermsField = () => {
+    if (!incotermsSelect || !incotermsOtherInput) return;
+    const toggleDetail = () => {
+      const needDetail = incotermsSelect.value === "기타";
+      if (incotermsDetailLabel) {
+        if (needDetail) {
+          incotermsDetailLabel.removeAttribute("hidden");
+        } else {
+          incotermsDetailLabel.setAttribute("hidden", "true");
+        }
+      }
+      incotermsOtherInput.disabled = !needDetail;
+      incotermsOtherInput.required = needDetail;
+      if (!needDetail) {
+        incotermsOtherInput.value = "";
+      }
+      updateStepActionState();
+    };
+
+    if (!incotermsSelect.dataset.boundIncoterms) {
+      incotermsSelect.addEventListener("change", toggleDetail);
+      form.addEventListener("reset", () => {
+        window.requestAnimationFrame(() => {
+          toggleDetail();
+        });
+      });
+      incotermsSelect.dataset.boundIncoterms = "true";
+    }
+
+    toggleDetail();
+  };
+
+  const setupItemTable = () => {
+    if (!itemsStep || !itemRows) return;
+
+    const state = form._itemTableState || {};
+    form._itemTableState = state;
+    if (typeof state.rowIdCounter !== "number") {
+      state.rowIdCounter = 0;
+    }
+
+    const itemSummaryContainer = itemsStep.querySelector('[data-item-summary]');
+    const itemQtySumEl = itemsStep.querySelector('[data-item-qty-sum]');
+    const itemTotalSumEl = itemsStep.querySelector('[data-item-total-sum]');
+    const qtyFormatter = new Intl.NumberFormat('ko-KR', { maximumFractionDigits: 0 });
+    const amountFormatter = new Intl.NumberFormat('ko-KR', { maximumFractionDigits: 2 });
+
+    const assignRowKey = (row) => {
+      if (!row) return;
+      if (!row.dataset.itemKey) {
+        state.rowIdCounter += 1;
+        row.dataset.itemKey = `item-${state.rowIdCounter}`;
+      }
+    };
+
+    const createRow = () => {
+      const row = document.createElement("tr");
+      row.setAttribute("data-item-row", "");
+      assignRowKey(row);
+      row.innerHTML = `
+        <td><input type="checkbox" data-item-select /></td>
+        <td><input type="number" name="itemNo" data-item-input data-item-no required readonly tabindex="-1" aria-readonly="true" /></td>
+        <td><input type="text" name="itemName" data-item-input required placeholder="예: 품명" /></td>
+        <td><input type="text" name="itemCategory" data-item-input required placeholder="예: 품목구분" /></td>
+        <td><input type="number" name="itemQuantity" data-item-input required min="0" step="1" placeholder="예: 10" /></td>
+        <td>
+          <select name="itemCurrency" data-item-input required>
+            ${ITEM_CURRENCY_OPTIONS_HTML}
+          </select>
+        </td>
+        <td><input type="number" name="itemUnitPrice" data-item-input required min="0" step="0.01" placeholder="예: 1200" /></td>
+        <td><input type="number" name="itemTotal" data-item-input required min="0" step="0.01" placeholder="예: 12000" /></td>
+        <td>
+          <div class="item-origin-field">
+            <select name="itemOrigin" data-item-input required data-item-origin-select>
+              ${ITEM_ORIGIN_OPTIONS_HTML}
+            </select>
+            <input type="text" name="itemOriginOther" data-item-origin-other data-item-input placeholder="생산국을 입력하세요" hidden disabled />
+          </div>
+        </td>
+      `;
+      return row;
+    };
+
+    const setupOriginField = (row) => {
+      const originSelect = row.querySelector('[data-item-origin-select]');
+      const originOtherInput = row.querySelector('[data-item-origin-other]');
+      if (!(originSelect instanceof HTMLSelectElement) || !(originOtherInput instanceof HTMLInputElement)) {
+        return;
+      }
+
+      const syncOriginField = () => {
+        const needCustom = originSelect.value === "기타";
+        originOtherInput.hidden = !needCustom;
+        originOtherInput.disabled = !needCustom;
+        originOtherInput.required = needCustom;
+        if (!needCustom) {
+          originOtherInput.value = "";
+        }
+        updateStepActionState();
+      };
+
+      if (!originSelect.dataset.boundOrigin) {
+        originSelect.addEventListener("change", syncOriginField);
+        originSelect.dataset.boundOrigin = "true";
+      }
+
+      if (!originSelect.value) {
+        originSelect.selectedIndex = 0;
+      }
+      syncOriginField();
+    };
+
+    const updateItemSummary = () => {
+      if (!(itemQtySumEl instanceof HTMLElement) || !(itemTotalSumEl instanceof HTMLElement)) return;
+      const rows = $$('[data-item-row]', itemRows);
+      let quantitySum = 0;
+      let amountSum = 0;
+      rows.forEach((row) => {
+        const qtyInput = row.querySelector('input[name="itemQuantity"]');
+        const totalInput = row.querySelector('input[name="itemTotal"]');
+        const qtyValue = qtyInput instanceof HTMLInputElement ? Number(qtyInput.value) : NaN;
+        const totalValue = totalInput instanceof HTMLInputElement ? Number(totalInput.value) : NaN;
+        if (Number.isFinite(qtyValue)) {
+          quantitySum += qtyValue;
+        }
+        if (Number.isFinite(totalValue)) {
+          amountSum += totalValue;
+        }
+      });
+      itemQtySumEl.textContent = qtyFormatter.format(quantitySum);
+      itemTotalSumEl.textContent = amountFormatter.format(amountSum);
+      if (itemSummaryContainer instanceof HTMLElement) {
+        itemSummaryContainer.dataset.empty = rows.length ? "false" : "true";
+      }
+    };
+
+    const updateRowNumbers = () => {
+      const numberInputs = $$('input[name="itemNo"]', itemRows);
+      numberInputs.forEach((input, idx) => {
+        input.value = String(idx + 1);
+      });
+    };
+
+    const addRow = () => {
+      const row = createRow();
+      itemRows.appendChild(row);
+      setupOriginField(row);
+      updateRowNumbers();
+      updateItemSummary();
+      updateStepActionState();
+    };
+
+    const resetRows = () => {
+      itemRows.innerHTML = "";
+      addRow();
+    };
+
+    const removeSelectedRows = () => {
+      const rows = $$('[data-item-row]', itemRows);
+      const selectedRows = rows.filter((row) => row.querySelector('[data-item-select]')?.checked);
+      if (!selectedRows.length) {
+        alert("삭제할 행을 선택해주세요.");
+        return;
+      }
+      selectedRows.forEach((row) => row.remove());
+      if (!itemRows.children.length) {
+        addRow();
+      } else {
+        updateRowNumbers();
+        updateItemSummary();
+        updateStepActionState();
+      }
+    };
+
+    if (!state.bound) {
+      addItemButton?.addEventListener("click", () => {
+        addRow();
+      });
+      removeItemButton?.addEventListener("click", () => {
+        removeSelectedRows();
+      });
+      const handleItemChange = () => {
+        updateItemSummary();
+        updateStepActionState();
+      };
+      itemRows.addEventListener("input", handleItemChange);
+      itemRows.addEventListener("change", handleItemChange);
+      form.addEventListener("reset", () => {
+        window.requestAnimationFrame(() => {
+          resetRows();
+          updateItemSummary();
+          updateStepActionState();
+        });
+      });
+      state.bound = true;
+    }
+
+    if (!state.initialized) {
+      resetRows();
+      state.initialized = true;
+    } else if (!itemRows.children.length) {
+      resetRows();
+    } else {
+      const rows = $$('[data-item-row]', itemRows);
+      rows.forEach((row) => {
+        assignRowKey(row);
+        setupOriginField(row);
+      });
+      updateRowNumbers();
+      updateItemSummary();
+      updateStepActionState();
+    }
+    updateItemSummary();
+  };
+
+  const setupPackingStep = () => {
+    const packingStep = form.querySelector('[data-packing-step]');
+    if (!packingStep) return;
+
+    const state = form._packingState || {};
+    if (!Array.isArray(state.packings)) {
+      state.packings = [];
+    }
+    if (!(state.selection instanceof Set)) {
+      state.selection = new Set(state.selection ? Array.from(state.selection) : []);
+    }
+    if (!Array.isArray(state.items)) {
+      state.items = [];
+    }
+    if (typeof state.formOpen !== 'boolean') {
+      state.formOpen = false;
+    }
+    form._packingState = state;
+
+    const dimensionFormatter = new Intl.NumberFormat('ko-KR', {
+      maximumFractionDigits: 2,
+      minimumFractionDigits: 0,
+    });
+    const quantityFormatter = new Intl.NumberFormat('ko-KR', {
+      maximumFractionDigits: 0,
+    });
+
+    const itemRowsRoot = form.querySelector('[data-item-rows]');
+    const packingList = packingStep.querySelector('[data-packing-list]');
+    const packingEmpty = packingStep.querySelector('[data-packing-empty]');
+    const packingItemsBody = packingStep.querySelector('[data-packing-items-body]');
+    const selectAllCheckbox = packingStep.querySelector('[data-packing-select-all]');
+    const createButton = packingStep.querySelector('[data-packing-create]');
+    const openButton = packingStep.querySelector('[data-packing-open]');
+    const panel = packingStep.querySelector('[data-packing-panel]');
+    const closeButton = packingStep.querySelector('[data-packing-close]');
+    const cancelButton = packingStep.querySelector('[data-packing-cancel]');
+    const inputs = {
+      name: packingStep.querySelector('[data-packing-field="name"]'),
+      length: packingStep.querySelector('[data-packing-field="length"]'),
+      width: packingStep.querySelector('[data-packing-field="width"]'),
+      height: packingStep.querySelector('[data-packing-field="height"]'),
+      cbm: packingStep.querySelector('[data-packing-field="cbm"]'),
+    };
+
+    const ensureDefaultName = () => {
+      if (!(inputs.name instanceof HTMLInputElement)) return;
+      if ((inputs.name.value ?? '').trim() === '') {
+        const nextIndex = state.packings.length + 1;
+        inputs.name.value = `Packing ${String(nextIndex).padStart(2, '0')}`;
+      }
+    };
+
+    const getInputNumber = (input) => {
+      if (!(input instanceof HTMLInputElement)) return null;
+      const value = Number(input.value);
+      return Number.isFinite(value) ? value : null;
+    };
+
+    const gatherItems = () => {
+      const rows = itemRowsRoot ? $$('[data-item-row]', itemRowsRoot) : [];
+      return rows
+        .map((row, index) => {
+          const key = row.dataset.itemKey || `row-${index}`;
+          const getValue = (selector) => {
+            const el = row.querySelector(selector);
+            return el && 'value' in el ? String(el.value).trim() : '';
+          };
+          const quantityValue = Number(getValue('input[name="itemQuantity"]'));
+          return {
+            key,
+            no: getValue('input[name="itemNo"]'),
+            name: getValue('input[name="itemName"]'),
+            category: getValue('input[name="itemCategory"]'),
+            quantity: Number.isFinite(quantityValue) ? quantityValue : 0,
+          };
+        })
+        .filter((item) => item.name || item.category || item.no);
+    };
+
+    const updateSelectAllState = () => {
+      if (!(selectAllCheckbox instanceof HTMLInputElement)) return;
+      const total = state.items.length;
+      const selected = state.items.filter((item) => state.selection.has(item.key)).length;
+      selectAllCheckbox.disabled = total === 0;
+      selectAllCheckbox.checked = total > 0 && selected === total;
+      selectAllCheckbox.indeterminate = selected > 0 && selected < total;
+    };
+
+    const renderPackings = () => {
+      if (!(packingList instanceof HTMLElement)) return;
+      const itemsMap = new Map(state.items.map((item) => [item.key, item]));
+      state.packings.forEach((packing) => {
+        packing.itemKeys = Array.isArray(packing.itemKeys)
+          ? packing.itemKeys.filter((key) => itemsMap.has(key))
+          : [];
+      });
+      if (packingEmpty instanceof HTMLElement) {
+        packingEmpty.hidden = state.packings.length > 0;
+      }
+      if (!state.packings.length) {
+        packingList.innerHTML = '';
+        return;
+      }
+      packingList.innerHTML = state.packings
+        .map((packing) => {
+          const items = packing.itemKeys.map((key) => itemsMap.get(key)).filter(Boolean);
+          const totalQuantity = items.reduce((sum, item) => {
+            const quantity = Number(item?.quantity ?? 0);
+            return sum + (Number.isFinite(quantity) ? quantity : 0);
+          }, 0);
+          const dimensionTags = [
+            { label: 'L', value: packing.length },
+            { label: 'W', value: packing.width },
+            { label: 'H', value: packing.height },
+          ]
+            .filter((dim) => Number.isFinite(dim.value))
+            .map((dim) => `<span>${escapeHtml(dim.label)} ${escapeHtml(dimensionFormatter.format(dim.value))}</span>`)
+            .join('');
+          const cbmTag = Number.isFinite(packing.cbm)
+            ? `<span>CBM ${escapeHtml(packing.cbm.toFixed(3))}</span>`
+            : '';
+          const itemsList = items.length
+            ? items
+                .map((item) => {
+                  const name = item?.name ? escapeHtml(item.name) : '-';
+                  const category = item?.category ? ` (${escapeHtml(item.category)})` : '';
+                  const quantityText = escapeHtml(quantityFormatter.format(Number(item?.quantity ?? 0)));
+                  return `<li><span>${name}${category}</span><span>${quantityText}</span></li>`;
+                })
+                .join('')
+            : '<li><span>품목 없음</span><span>-</span></li>';
+          return `
+            <li class="packing-card">
+              <button type="button" class="packing-card-delete" data-packing-delete data-packing-id="${escapeHtml(
+                packing.id
+              )}" aria-label="팩킹 삭제">✕</button>
+              <div class="packing-card-title">${escapeHtml(packing.name)}</div>
+              <div class="packing-card-meta">${dimensionTags}${cbmTag}</div>
+              <div class="packing-card-summary">
+                <span>품목 ${escapeHtml(String(items.length))}개</span>
+                <span>총 수량 ${escapeHtml(quantityFormatter.format(totalQuantity))}</span>
+              </div>
+              <div class="packing-card-details">
+                <h5>${escapeHtml(packing.name)} 내용</h5>
+                <ul>${itemsList}</ul>
+              </div>
+            </li>
+          `;
+        })
+        .join('');
+    };
+
+    const renderItemTable = () => {
+      state.items = gatherItems();
+      const validKeys = new Set(state.items.map((item) => item.key));
+      state.selection = new Set([...state.selection].filter((key) => validKeys.has(key)));
+      if (!(packingItemsBody instanceof HTMLElement)) {
+        updateSelectAllState();
+        renderPackings();
+        updateStepActionState();
+        return;
+      }
+      const rowsHtml = state.items.length
+        ? state.items
+            .map(
+              (item) => `
+                <tr data-packing-item-row data-item-key="${escapeHtml(item.key)}">
+                  <td class="text-center">
+                    <input type="checkbox" data-packing-item-checkbox data-item-key="${escapeHtml(item.key)}"${
+                      state.selection.has(item.key) ? ' checked' : ''
+                    } />
+                  </td>
+                  <td>${escapeHtml(item.no || '-')}</td>
+                  <td>${escapeHtml(item.name || '-')}</td>
+                  <td>${escapeHtml(item.category || '-')}</td>
+                  <td class="text-right">${escapeHtml(quantityFormatter.format(Number(item.quantity ?? 0)))}</td>
+                </tr>
+              `
+            )
+            .join('')
+        : '<tr><td colspan="5" class="packing-items-empty">품목정보 단계에서 입력한 품목이 없습니다.</td></tr>';
+      packingItemsBody.innerHTML = rowsHtml;
+      updateSelectAllState();
+      renderPackings();
+      updateStepActionState();
+    };
+
+    const updateCbmFromDimensions = () => {
+      if (!(inputs.cbm instanceof HTMLInputElement)) return;
+      const lengthValue = getInputNumber(inputs.length);
+      const widthValue = getInputNumber(inputs.width);
+      const heightValue = getInputNumber(inputs.height);
+      if (inputs.cbm.dataset.manual === 'true') {
+        return;
+      }
+      if (
+        Number.isFinite(lengthValue) &&
+        Number.isFinite(widthValue) &&
+        Number.isFinite(heightValue)
+      ) {
+        const cbmValue = (lengthValue * widthValue * heightValue) / 1_000_000;
+        if (Number.isFinite(cbmValue)) {
+          inputs.cbm.value = cbmValue === 0 ? '0' : cbmValue.toFixed(3);
+        } else {
+          inputs.cbm.value = '';
+        }
+      } else {
+        inputs.cbm.value = '';
+      }
+    };
+
+    const resetDimensionFields = () => {
+      if (inputs.length instanceof HTMLInputElement) inputs.length.value = '';
+      if (inputs.width instanceof HTMLInputElement) inputs.width.value = '';
+      if (inputs.height instanceof HTMLInputElement) inputs.height.value = '';
+      if (inputs.cbm instanceof HTMLInputElement) {
+        inputs.cbm.value = '';
+        delete inputs.cbm.dataset.manual;
+      }
+    };
+
+    const openForm = ({ focusInput = true } = {}) => {
+      if (state.formOpen) {
+        if (focusInput && inputs.name instanceof HTMLInputElement) {
+          inputs.name.focus();
+          inputs.name.select();
+        }
+        return;
+      }
+      state.formOpen = true;
+      if (panel instanceof HTMLElement) {
+        panel.hidden = false;
+      }
+      if (openButton instanceof HTMLButtonElement) {
+        openButton.hidden = true;
+      }
+      ensureDefaultName();
+      if (focusInput && inputs.name instanceof HTMLInputElement) {
+        inputs.name.focus();
+        inputs.name.select();
+      }
+    };
+
+    const closeForm = ({ resetFields = false, focusTrigger = false } = {}) => {
+      state.formOpen = false;
+      if (panel instanceof HTMLElement) {
+        panel.hidden = true;
+      }
+      if (openButton instanceof HTMLButtonElement) {
+        openButton.hidden = false;
+        if (focusTrigger) {
+          window.requestAnimationFrame(() => openButton.focus());
+        }
+      }
+      if (resetFields) {
+        if (inputs.name instanceof HTMLInputElement) {
+          inputs.name.value = '';
+        }
+        resetDimensionFields();
+      }
+    };
+
+    const syncFormVisibility = () => {
+      if (state.formOpen) {
+        openForm({ focusInput: false });
+      } else {
+        closeForm({ resetFields: false, focusTrigger: false });
+      }
+    };
+
+    const applyVisibility = (isActive) => {
+      packingStep.dataset.packingVisible = isActive ? 'true' : 'false';
+      if (isActive) {
+        packingStep.removeAttribute('aria-hidden');
+      } else {
+        packingStep.setAttribute('aria-hidden', 'true');
+      }
+      if (typeof packingStep.toggleAttribute === 'function') {
+        packingStep.toggleAttribute('inert', !isActive);
+      }
+      if (isActive) {
+        syncFormVisibility();
+      } else {
+        if (panel instanceof HTMLElement) {
+          panel.hidden = true;
+        }
+        if (openButton instanceof HTMLButtonElement) {
+          openButton.hidden = false;
+        }
+      }
+    };
+
+    const handleCreate = () => {
+      if (!(inputs.name instanceof HTMLInputElement)) return;
+      const name = inputs.name.value.trim();
+      if (!name) {
+        alert('팩킹명을 입력해주세요.');
+        inputs.name.focus();
+        return;
+      }
+      const lengthValue = getInputNumber(inputs.length);
+      if (!Number.isFinite(lengthValue) || lengthValue <= 0) {
+        alert('Length 값을 입력해주세요.');
+        inputs.length?.focus();
+        return;
+      }
+      const widthValue = getInputNumber(inputs.width);
+      if (!Number.isFinite(widthValue) || widthValue <= 0) {
+        alert('Width 값을 입력해주세요.');
+        inputs.width?.focus();
+        return;
+      }
+      const heightValue = getInputNumber(inputs.height);
+      if (!Number.isFinite(heightValue) || heightValue <= 0) {
+        alert('Height 값을 입력해주세요.');
+        inputs.height?.focus();
+        return;
+      }
+      const selectedItems = state.items.filter((item) => state.selection.has(item.key));
+      if (!selectedItems.length) {
+        alert('팩킹에 포함할 품목을 선택해주세요.');
+        return;
+      }
+      const cbmInputValue = getInputNumber(inputs.cbm);
+      const computedCbm = (lengthValue * widthValue * heightValue) / 1_000_000;
+      const cbmValue = Number.isFinite(cbmInputValue) ? cbmInputValue : computedCbm;
+      const packing = {
+        id: `packing-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        name,
+        length: lengthValue,
+        width: widthValue,
+        height: heightValue,
+        cbm: Number.isFinite(cbmValue) ? Number(cbmValue) : null,
+        itemKeys: selectedItems.map((item) => item.key),
+      };
+      state.packings.push(packing);
+      state.selection.clear();
+      if (inputs.name instanceof HTMLInputElement) {
+        inputs.name.value = '';
+      }
+      resetDimensionFields();
+      renderItemTable();
+      renderPackings();
+      ensureDefaultName();
+      updateStepActionState();
+    };
+
+    const handleDelete = (id) => {
+      if (!id) return;
+      state.packings = state.packings.filter((packing) => packing.id !== id);
+      renderPackings();
+      ensureDefaultName();
+      updateStepActionState();
+    };
+
+    if (!state.bound) {
+      if (itemRowsRoot instanceof HTMLElement) {
+        const handleItemsChange = () => {
+          renderItemTable();
+        };
+        itemRowsRoot.addEventListener('input', handleItemsChange);
+        itemRowsRoot.addEventListener('change', handleItemsChange);
+      }
+      if (packingItemsBody instanceof HTMLElement) {
+        packingItemsBody.addEventListener('change', (event) => {
+          const checkbox = event.target.closest('[data-packing-item-checkbox]');
+          if (!(checkbox instanceof HTMLInputElement)) return;
+          const key = checkbox.dataset.itemKey;
+          if (!key) return;
+          if (checkbox.checked) {
+            state.selection.add(key);
+          } else {
+            state.selection.delete(key);
+          }
+          updateSelectAllState();
+        });
+      }
+      if (selectAllCheckbox instanceof HTMLInputElement) {
+        selectAllCheckbox.addEventListener('change', () => {
+          if (selectAllCheckbox.checked) {
+            state.selection = new Set(state.items.map((item) => item.key));
+          } else {
+            state.selection.clear();
+          }
+          renderItemTable();
+        });
+      }
+      if (createButton instanceof HTMLButtonElement) {
+        createButton.addEventListener('click', handleCreate);
+      }
+      if (openButton instanceof HTMLButtonElement) {
+        openButton.addEventListener('click', (event) => {
+          event.preventDefault();
+          openForm();
+        });
+      }
+      if (closeButton) {
+        closeButton.addEventListener('click', (event) => {
+          event.preventDefault();
+          closeForm({ focusTrigger: true });
+        });
+      }
+      if (cancelButton) {
+        cancelButton.addEventListener('click', (event) => {
+          event.preventDefault();
+          state.selection.clear();
+          renderItemTable();
+          closeForm({ resetFields: true, focusTrigger: true });
+        });
+      }
+      if (packingList instanceof HTMLElement) {
+        packingList.addEventListener('click', (event) => {
+          const button = event.target.closest('[data-packing-delete]');
+          if (!(button instanceof HTMLButtonElement)) return;
+          const packingId = button.dataset.packingId;
+          handleDelete(packingId);
+        });
+      }
+      if (inputs.cbm instanceof HTMLInputElement) {
+        inputs.cbm.addEventListener('input', () => {
+          inputs.cbm.dataset.manual = inputs.cbm.value ? 'true' : '';
+        });
+      }
+      [inputs.length, inputs.width, inputs.height].forEach((input) => {
+        if (input instanceof HTMLInputElement) {
+          input.addEventListener('input', () => {
+            updateCbmFromDimensions();
+          });
+        }
+      });
+      form.addEventListener('reset', () => {
+        window.requestAnimationFrame(() => {
+          state.packings = [];
+          state.selection = new Set();
+          state.items = [];
+          closeForm({ resetFields: true });
+          renderItemTable();
+          renderPackings();
+          ensureDefaultName();
+          updateStepActionState();
+        });
+      });
+      state.bound = true;
+    }
+
+    state.openForm = (options) => openForm(options || {});
+    state.closeForm = (options) => closeForm(options || {});
+
+    renderItemTable();
+    ensureDefaultName();
+    renderPackings();
+    updateStepActionState();
+
+    syncPackingVisibility = (isActive) => {
+      applyVisibility(isActive);
+    };
+
+    applyVisibility(currentStep === packingStepIndex);
+  };
+
+  const showStep = (index) => {
+    currentStep = Math.max(0, Math.min(index, totalSteps - 1));
+    steps.forEach((stepEl, idx) => {
+      if (idx === currentStep) {
+        stepEl.removeAttribute("hidden");
+      } else {
+        stepEl.setAttribute("hidden", "true");
+      }
+    });
+    if (stepIndicator) {
+      stepIndicator.textContent = `${currentStep + 1} / ${totalSteps}`;
+    }
+    if (stepTitle) {
+      const active = steps[currentStep];
+      stepTitle.textContent = active?.dataset.stepTitle ?? "";
+    }
+    if (typeof syncPackingVisibility === "function" && packingStepIndex !== -1) {
+      syncPackingVisibility(currentStep === packingStepIndex);
+    }
+    updateStepActionState();
+  };
+
+  const validateStep = (index) => {
+    const stepEl = steps[index];
+    if (!stepEl) return true;
+    const requiredGroups = $$('[data-required-group]', stepEl);
+    for (const group of requiredGroups) {
+      const options = $$('input[type="checkbox"]', group).filter((opt) => !opt.disabled);
+      if (!options.some((opt) => opt.checked)) {
+        alert("전략물자 여부를 선택해주세요.");
+        options[0]?.focus();
+        return false;
+      }
+    }
+    const hiddenRequired = $$('[data-required-hidden]', stepEl);
+    for (const hidden of hiddenRequired) {
+      if (hidden instanceof HTMLInputElement || hidden instanceof HTMLTextAreaElement) {
+        if ((hidden.value ?? "").trim() === "") {
+          const message = hidden.dataset.requiredMessage || "필수 항목을 선택해주세요.";
+          alert(message);
+          const focusSelector = hidden.dataset.targetSelector;
+          const target = focusSelector ? stepEl.querySelector(focusSelector) : null;
+          if (target instanceof HTMLElement) {
+            target.focus();
+          }
+          return false;
+        }
+      }
+    }
+    if (expertSearchContainer && stepEl.contains(expertSearchContainer)) {
+      const requiresExpert = (strategicValueInput?.value || "") === "전략물자 수출";
+      const selectedValue =
+        expertSelectedValueInput instanceof HTMLInputElement
+          ? (expertSelectedValueInput.value || "").trim()
+          : "";
+      if (requiresExpert && !selectedValue) {
+        alert("전략물자 전문판정서를 선택해주세요.");
+        if (expertKeywordInput instanceof HTMLInputElement) {
+          expertKeywordInput.focus();
+        }
+        return false;
+      }
+    }
+    const inputs = $$("input, select, textarea", stepEl);
+    for (const input of inputs) {
+      if (input.disabled) continue;
+      if (typeof input.reportValidity === "function" && !input.reportValidity()) {
+        input.focus();
+        return false;
+      }
+    }
+    if (stepEl.hasAttribute("data-packing-step")) {
+      const packingState = form._packingState;
+      if (!packingState || !Array.isArray(packingState.packings) || !packingState.packings.length) {
+        alert("최소 한 개 이상의 팩킹을 생성해주세요.");
+        if (packingState && typeof packingState.openForm === 'function') {
+          packingState.openForm({ focusInput: false });
+        }
+        const target = stepEl.querySelector('[data-packing-create]');
+        if (target instanceof HTMLElement) {
+          target.focus();
+        }
+        return false;
+      }
+      const invalidPacking = packingState.packings.find(
+        (packing) => !Array.isArray(packing.itemKeys) || packing.itemKeys.length === 0
+      );
+      if (invalidPacking) {
+        alert("각 팩킹에 포함할 품목을 선택해주세요.");
+        if (packingState && typeof packingState.openForm === 'function') {
+          packingState.openForm({ focusInput: false });
+        }
+        const target = stepEl.querySelector('[data-packing-create]');
+        if (target instanceof HTMLElement) {
+          target.focus();
+        }
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const handleNext = () => {
+    if (!validateStep(currentStep)) return;
+    if (currentStep < totalSteps - 1) {
+      showStep(currentStep + 1);
+    }
+  };
+
+  const handlePrev = () => {
+    if (currentStep > 0) {
+      showStep(currentStep - 1);
+    }
+  };
+
+  const handleSaveDraft = () => {
+    if (!formHasInput(form)) {
+      alert("입력된 내용이 없습니다.");
+      return;
+    }
+    const values = collectFormValues(form);
+    addDraftEntry(values);
+    dialog.close();
+  };
+
+  const handleCancel = () => {
+    const needConfirm = currentStep > 0 || formHasInput(form);
+    if (!needConfirm || window.confirm("정말로 취소하시겠습니까?")) {
+      form.reset();
+      dialog.close();
+    }
+  };
+
+  if (nextButton) {
+    nextButton.onclick = handleNext;
+  }
+  if (prevButton) {
+    prevButton.onclick = handlePrev;
+  }
+  if (saveButton) {
+    saveButton.onclick = handleSaveDraft;
+  }
+  if (cancelButton) {
+    cancelButton.onclick = handleCancel;
+  }
+
+  if (!form.dataset.boundStepState) {
+    form.addEventListener("input", () => updateStepActionState());
+    form.addEventListener("change", () => updateStepActionState());
+    form.dataset.boundStepState = "true";
+  }
+
+  if (exportTypeSelect && !exportTypeSelect.dataset.boundDetail) {
+    exportTypeSelect.addEventListener("change", toggleExportTypeDetail);
+    exportTypeSelect.dataset.boundDetail = "true";
+  }
+
+  setupExpertSearch();
+  setupStrategicGroup();
+  setupCountrySelector();
+  setupSimpleCountrySelects();
+  setupNotifyCopy();
+  setupTransportModeField();
+  setupIncotermsField();
+  setupItemTable();
+  setupPackingStep();
+  toggleExportTypeDetail();
+
+  form.onsubmit = async (e) => {
+    e.preventDefault();
+    if (currentStep !== totalSteps - 1) {
+      if (validateStep(currentStep)) {
+        handleNext();
+      }
+      return;
+    }
+    if (!form.reportValidity()) return;
+
+    const values = collectFormValues(form);
+    const payload = mapFormDataToPayload(values);
+
+    try {
+      const res = await fetch("/api/exports", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error("등록 실패");
+      await res.json();
+      dialog.close();
+      form.reset();
+      await fetchAndRender({ page: 1 });
+    } catch (err) {
+      alert(err.message || "등록 중 오류");
+    }
+  };
+
+  dialog.showModal();
+  showStep(currentStep);
+}
+
+/* Router */
+function navigate(pathname) {
+  setMenuOpen(false);
+  if (location.pathname === pathname) return;
+  window.history.pushState({}, "", pathname);
+  render(pathname);
+}
+function render(pathname = location.pathname) {
+  setMenuOpen(false);
+  const handler = routes[pathname];
+  if (handler) {
+    handler();
+  } else {
+    renderNotFound();
+  }
+}
+function renderNotFound() {
+  setTopbarActive("");
+  document.title = "404";
+  app.innerHTML = `<section class="card"><h2>404</h2><p>페이지를 찾을 수 없습니다.</p></section>`;
+  app.focus();
+}
+
+/* Delegated navigation */
+window.addEventListener("click", (e) => {
+  const link = e.target.closest("[data-link]");
+  if (!link) return;
+  const href = link.getAttribute("href") || link.dataset.link;
+  if (!href) return;
+  e.preventDefault();
+  navigate(href);
+});
+window.addEventListener("popstate", () => render());
+
+/* Utils */
+function escapeHtml(s){return s.replace(/[&<>"']/g,m=>({ "&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;" }[m]))}
+
+// 초기화
+$("#year").textContent = new Date().getFullYear();
+render(location.pathname || "/");
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a self-contained `standalone.html` that inlines the existing styles, markup, and interaction logic
- provide an in-browser data store and fetch shim so the export dashboard works without a server and refresh the table after submissions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5f424c89c8329822332c254c4bd4a