### PR TITLE
Adjust packing step layout and drag workflow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -327,9 +327,7 @@
                       <th scope="col">NO</th>
                       <th scope="col">품명</th>
                       <th scope="col">품목구분</th>
-                      <th scope="col">총수량</th>
                       <th scope="col">잔량</th>
-                      <th scope="col" class="packing-item-actions-header">배정</th>
                     </tr>
                   </thead>
                   <tbody data-packing-items-body></tbody>
@@ -341,7 +339,7 @@
               <header class="packing-panel-header">
                 <div class="packing-panel-heading">
                   <h4>박스(Packing)</h4>
-                  <p>박스를 생성하고 품목을 드래그하거나 배정 버튼으로 담아주세요.</p>
+                  <p>박스를 생성하고 품목을 드래그하여 담아주세요.</p>
                 </div>
                 <div class="packing-layout-actions">
                   <button type="button" class="btn primary" data-packing-open>패킹 추가</button>
@@ -375,7 +373,7 @@
                         <input type="number" name="packingHeight" min="0" step="0.1" data-packing-field="height" placeholder="0" />
                       </label>
                       <label>CBM
-                        <input type="number" name="packingCbm" min="0" step="0.001" data-packing-field="cbm" placeholder="0.000" />
+                        <input type="number" name="packingCbm" min="0" step="0.001" data-packing-field="cbm" placeholder="자동 계산" readonly />
                       </label>
                       <label>무게 (kg)
                         <input type="number" name="packingWeight" min="0" step="0.1" data-packing-field="weight" placeholder="0" />
@@ -409,24 +407,29 @@
   <dialog id="packingAssignDialog" aria-labelledby="packingAssignTitle">
     <form method="dialog" class="packing-assign" data-packing-assign-form>
       <header class="packing-assign-header">
-        <h3 id="packingAssignTitle">품목 배정</h3>
+        <h3 id="packingAssignTitle">품목 담기</h3>
         <p class="packing-assign-subtitle" data-packing-assign-subtitle></p>
       </header>
       <div class="packing-assign-body">
         <p class="packing-assign-remain">잔량: <strong data-packing-assign-remain>0</strong>개</p>
-        <label>박스 선택
-          <select data-packing-assign-box required></select>
-        </label>
-        <label>배정 수량
-          <input type="number" min="1" step="1" data-packing-assign-qty required />
-        </label>
-        <p class="packing-assign-hint">1 이상, 잔량 범위 내의 정수를 입력하세요.</p>
+        <div class="packing-assign-inline">
+          <label for="packingAssignQty">수량</label>
+          <input
+            id="packingAssignQty"
+            type="number"
+            min="1"
+            step="1"
+            data-packing-assign-qty
+            required
+          />
+          <button type="submit" class="btn primary" data-packing-assign-confirm>확인</button>
+        </div>
+        <p class="packing-assign-hint">드래그한 품목에서 담을 개수를 입력하세요.</p>
         <p class="packing-assign-error" data-packing-assign-error aria-live="polite"></p>
       </div>
-      <menu class="packing-assign-actions">
+      <div class="packing-assign-footer">
         <button type="button" class="btn" data-packing-assign-cancel>취소</button>
-        <button type="submit" class="btn primary" data-packing-assign-confirm>배정</button>
-      </menu>
+      </div>
     </form>
   </dialog>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -233,7 +233,7 @@ input,select,textarea{padding:.5rem;border:1px solid var(--line);border-radius:6
 /* Packing step */
 .step[data-packing-step]{display:block}
 .step[data-packing-step][data-packing-visible="false"]{display:none}
-.packing-board{display:grid;grid-template-columns:minmax(0,1.1fr) minmax(0,1fr);gap:1.5rem;align-items:flex-start}
+.packing-board{display:flex;flex-direction:column;gap:1.5rem;align-items:stretch}
 .packing-layout-actions{display:flex;gap:.5rem}
 .packing-panel{border:1px solid var(--line);border-radius:12px;padding:1.25rem;background:#f7f9ff;display:flex;flex-direction:column;gap:.85rem}
 .packing-panel[hidden]{display:none!important}
@@ -270,25 +270,20 @@ input,select,textarea{padding:.5rem;border:1px solid var(--line);border-radius:6
 .packing-form label{font-weight:600;color:#202b52}
 .packing-form input{width:100%}
 .packing-dimension-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.75rem}
+.packing-form input[readonly]{background:#f2f4fa;color:#5d678c;cursor:not-allowed}
 .packing-form-actions{display:flex;justify-content:flex-end;gap:.5rem}
 .packing-items{border:1px solid var(--line);border-radius:12px;padding:1.25rem;background:#fff;display:flex;flex-direction:column;gap:1rem;min-height:100%}
 .packing-items-table table{width:100%;border-collapse:collapse}
 .packing-items-table th,.packing-items-table td{padding:.6rem .75rem;text-align:left}
 .packing-items-table th{background:#f1f4ff;font-size:.85rem;color:#26315a}
+.packing-items-table td:nth-child(4),.packing-items-table th:nth-child(4){text-align:right}
 .packing-items-table td{border-top:1px solid #e5e9f9;vertical-align:middle;font-size:.9rem}
 .packing-items-table tbody tr:first-child td{border-top:none}
+.packing-item-no{text-align:center;font-weight:600;color:#1d2e5b}
 .packing-item-name{font-weight:600;color:#1a2553}
-.packing-item-kind{display:block;font-size:.78rem;color:#6b759d;margin-top:.15rem}
-.packing-item-handle{font-size:1rem;margin-right:.5rem;color:#7a86b4;cursor:grab}
-.packing-item-handle[aria-hidden="true"]{display:none}
-.packing-item-qty{font-variant-numeric:tabular-nums;font-weight:600;color:#1f2a56}
-.packing-item-remainder{font-variant-numeric:tabular-nums;font-weight:700}
-.packing-item-actions-header{text-align:center}
-.packing-item-actions{display:flex;justify-content:center}
-.packing-item-actions .btn{min-width:0;padding:.35rem .65rem;font-size:.8rem}
+.packing-item-remainder{font-variant-numeric:tabular-nums;font-weight:700;color:#1f2a56}
 .packing-item-row{cursor:grab}
 .packing-item-row[data-disabled="true"]{opacity:.55;cursor:not-allowed}
-.packing-item-row[data-disabled="true"] .packing-item-handle{cursor:not-allowed;color:#b3badc}
 .packing-items-empty{padding:1rem;text-align:center;color:#6c779d;font-size:.9rem}
 .step[data-packing-step][data-dragging="true"] .packing-card{transition:none}
 .packing-card[data-droppable="true"]::after{content:"드롭하여 배정";position:absolute;inset:auto 0 0;display:block;background:rgba(21,62,138,.9);color:#fff;padding:.4rem .75rem;font-size:.78rem;text-align:center}
@@ -300,19 +295,19 @@ input,select,textarea{padding:.5rem;border:1px solid var(--line);border-radius:6
 .packing-assign{min-width:320px;display:flex;flex-direction:column;gap:1rem;padding:1.25rem 1.5rem}
 .packing-assign-header h3{margin:0;font-size:1.05rem;color:#122044}
 .packing-assign-subtitle{margin:.35rem 0 0;color:#3a4675;font-weight:600}
-.packing-assign-body{display:flex;flex-direction:column;gap:.65rem}
-.packing-assign-body label{display:flex;flex-direction:column;gap:.35rem;font-weight:600;color:#1f2a50}
-.packing-assign-body input,.packing-assign-body select{width:100%}
+.packing-assign-body{display:flex;flex-direction:column;gap:.75rem}
+.packing-assign-inline{display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:.5rem;align-items:center}
+.packing-assign-inline label{display:inline-flex;align-items:center;gap:.35rem;font-weight:600;color:#1f2a50}
+.packing-assign-inline input{width:100%;text-align:right;font-variant-numeric:tabular-nums}
 .packing-assign-remain{margin:0;font-size:.88rem;color:#3d4a79;font-weight:600}
 .packing-assign-hint{margin:0;color:#6a739b;font-size:.78rem}
 .packing-assign-error{margin:0;color:#d12f2f;font-size:.8rem;min-height:1em}
-.packing-assign-actions{display:flex;justify-content:flex-end;gap:.5rem;padding:0}
-.packing-assign-actions .btn{min-width:90px}
+.packing-assign-footer{display:flex;justify-content:flex-end;padding:0}
+.packing-assign-footer .btn{min-width:90px}
 #packingAssignDialog{border:none;border-radius:12px;padding:0;max-width:420px}
 #packingAssignDialog::backdrop{background:rgba(9,19,41,.45)}
 
 @media (max-width:1024px){
-  .packing-board{grid-template-columns:1fr}
   .packing-layout{order:2}
 }
 @media (max-width:720px){


### PR DESCRIPTION
## Summary
- stack the packing items and packing panels vertically, simplify the item grid columns, and make the CBM input read-only with automatic calculation hints
- overhaul the packing step logic to auto-compute CBM, refresh remainder tracking, and show a streamlined quantity dialog when dragging items into boxes
- update the related styles to support the new layout and the inline quantity confirmation prompt

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d7fea60c3c832990156ce2e86a735c