### PR TITLE
Improve export table layout

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -85,29 +85,29 @@ h1,h2,h3{margin:0 0 .75rem}
 
 /* Table */
 .table-card{display:flex;flex-direction:column;gap:1rem}
-.table-wrap{margin-top:0;overflow-x:visible}
-table{width:100%;border-collapse:collapse;table-layout:auto}
-.table-card table{min-width:0}
-th,td{border:1px solid var(--line);padding:.6rem .7rem;vertical-align:top;font-size:.85rem;line-height:1.45}
+.table-wrap{margin-top:0;overflow-x:auto;overflow-y:hidden}
+table{width:max-content;min-width:100%;border-collapse:collapse;table-layout:auto}
+.table-card table{min-width:100%}
+th,td{border:1px solid var(--line);padding:.6rem .7rem;vertical-align:middle;font-size:.85rem;line-height:1.35}
 th{background:#f5f5f5;text-align:left}
 tbody tr:hover{background:#fafcff}
 
 .export-table th{background:#e8eefc;text-align:center}
 .export-table col{width:auto!important}
 .export-table th{
-  white-space:normal;
-  line-height:1.4;
+  white-space:nowrap;
+  line-height:1.3;
   text-align:center;
   font-size:.82rem;
-  padding:.65rem .5rem;
+  padding:.45rem .5rem;
 }
 .export-table td{
-  white-space:normal;
+  white-space:nowrap;
   text-align:left;
   word-break:keep-all;
-  overflow-wrap:break-word;
+  overflow-wrap:normal;
   font-size:.82rem;
-  padding:.6rem .5rem;
+  padding:.5rem .5rem;
 }
 .export-table td[data-empty="true"]{color:#a3abbb;text-align:center;font-style:italic}
 .export-table td input[type="checkbox"]{width:16px;height:16px}
@@ -136,7 +136,7 @@ tbody tr:hover{background:#fafcff}
 
 @media (max-width:768px){
   .table-card{padding:1rem}
-  .table-wrap{overflow-x:visible}
+  .table-wrap{overflow-x:auto}
   .export-table th,.export-table td{font-size:.72rem}
 }
 


### PR DESCRIPTION
## Summary
- reduce export table header height and keep headers on a single line for a tighter look
- prevent export table cell contents from wrapping and adjust spacing for a cleaner grid
- enable horizontal scrolling on the table container so wide content can be viewed without wrapping

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68f9b53cd26c83298f8a75b7eeca83b7